### PR TITLE
docs: revamp and modernize MkDocs Material documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to the confluent documentation are recorded here.
+
+## Documentation revamp
+
+A repo-wide modernization of the MkDocs Material documentation. No source
+content was lost; the site builds cleanly (`mkdocs build`, 142 pages).
+
+### Added
+- Modern Material landing page (`docs/index.md`) with action buttons and
+  card-grid entry points (Get started / Install / Deploy / Reference /
+  Discover / API), replacing the previous flat feature list.
+- Curated navigation via new `.nav.yml` files for `user_reference`,
+  `troubleshooting`, `advanced_topics`, and `miscellaneous`, with titled
+  root-level sections. Sections are now ordered by logical flow instead of
+  alphabetically; the advanced topics group leads with confluent-native
+  material and follows with xCAT/legacy topics.
+- Page titles for pages that previously had none
+  (`miscellaneous/makelimitedtls.md`, `user_reference/diskless_memory_usage.md`).
+
+### Changed
+- Removed dead Jekyll front matter (`layout:`, `permalink:`, `toc:`) from
+  89 pages, leaving a clean `title:`. Blog/release-note front matter
+  (`date:`, `draft:`) was preserved so the release-notes blog keeps working.
+- Converted indented code blocks to fenced blocks with a language hint across
+  the `getting_started`, `user_reference`, and `troubleshooting` sections,
+  enabling syntax highlighting and the copy-to-clipboard button.
+
+### Fixed
+- Corrected 12 broken image links in `miscellaneous/proxmoxguide.md`
+  (`../../assets/` -> `../assets/`).
+- Fixed a link missing its `.md` extension in
+  `getting_started/installconfluent_rhel.md` (link to `switchtonginx`).
+- Fixed a release-note link to `nokia-confignotes.md` that resolved one
+  directory too high (`../` -> `../../`).
+- Fixed spelling typos across the docs (`confluennt`, `documentaion`,
+  `accomodate`, `occured`).
+
+### Removed
+- Deleted two empty 0-byte stub pages
+  (`miscellaneous/setupconfluent.md`, `miscellaneous/setupxcat.md`) and
+  removed them from navigation.

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -1,11 +1,11 @@
 nav:
-  - index.md
-  - getting_started
-  - user_reference
-  - troubleshooting
-  - advanced_topics
-  - miscellaneous
-  - manuals
-  - developer
-  - downloads.md
-  - release_notes
+  - Home: index.md
+  - Getting Started: getting_started
+  - User Reference: user_reference
+  - Troubleshooting: troubleshooting
+  - Advanced Topics: advanced_topics
+  - Miscellaneous: miscellaneous
+  - Manuals: manuals
+  - Developer: developer
+  - Downloads: downloads.md
+  - Release Notes: release_notes

--- a/docs/advanced_topics/.nav.yml
+++ b/docs/advanced_topics/.nav.yml
@@ -1,0 +1,29 @@
+nav:
+  # Confluent deployment and discovery
+  - confluentosdeploy.md
+  - confluentosdeployment.md
+  - confluentlimitationsosdeploy.md
+  - confluentdiscoverysetting.md
+  - confluentnodeassign.md
+  - confluentswitchdisco.md
+  - confluentenclosuredisco.md
+  - collective.md
+  - remoteconfluent.md
+  - driverupdatemedia.md
+  - nodemedia_caveats.md
+  - rh8installib.md
+  - sle152ibinstall.md
+  # xCAT interoperation and legacy topics
+  - xcatconfluentsetup.md
+  - confluenttoxcat.md
+  - xcatconfignotes.md
+  - xcataddingsnmp.md
+  - sharedinstallnotes.md
+  - sharedtftpnotes.md
+  - installxcat_rhel.md
+  - installxcat_suse.md
+  - el7rste.md
+  - sles12rste.md
+  - xcatramrootibboot.md
+  - xcatstatelessimagesles152.md
+  - switchtonginx.md

--- a/docs/advanced_topics/collective.md
+++ b/docs/advanced_topics/collective.md
@@ -1,8 +1,5 @@
 ---
-layout: page
 title: Confluent collective mode
-permalink: /documentation/collective.html
-toc: true
 ---
 
 The collective mode of confluent allows multiple confluent servers to act as one, providing

--- a/docs/advanced_topics/confluentdiscoverysetting.md
+++ b/docs/advanced_topics/confluentdiscoverysetting.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Confluent Discovery/Autosense setting
-permalink: /documentation/confluentdiscoverysetting.html
 ---
 
 Confluent has a setting called "discovery/autosense" which acts to enable or disable scanning network switches for MAC addresses, but also has the effect of enabling or disabling network booting of systems from Confluent. Having the setting disabled has the effect of preventing network booting of systems from Confluent (including for OS deployment), but will not affect systems booting from operating systems installed on local storage.

--- a/docs/advanced_topics/confluentenclosuredisco.md
+++ b/docs/advanced_topics/confluentenclosuredisco.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Confluent discovery of Enclosure based systems
-permalink: /documentation/confluentenclosuredisco.html
 ---
 
 When discovering SD530 servers with an SMM, the enclosure may be used as an indication

--- a/docs/advanced_topics/confluentlimitationsosdeploy.md
+++ b/docs/advanced_topics/confluentlimitationsosdeploy.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Limitations of usage of Confluent osdeploy initialize across multiple management nodes
-permalink: /documentation/confluentlimitationsosdeploy.html
 ---
 
 The Confluent "osdeploy initialize" command provides assistance in setting up facilities relating to deployment and access of managed nodes from one or more management nodes. Setting up these facilities involve accessing one or more shared files.

--- a/docs/advanced_topics/confluentnodeassign.md
+++ b/docs/advanced_topics/confluentnodeassign.md
@@ -1,8 +1,5 @@
 ---
-layout: page
 title: Manual discovery with nodediscover assign
-permalink: /documentation/confluentnodeassign.html
-toc: true
 ---
 
 Note that discovery in confluent is an optional process intended to aid with automatic gathering of mac addresses,

--- a/docs/advanced_topics/confluentosdeploy.md
+++ b/docs/advanced_topics/confluentosdeploy.md
@@ -1,8 +1,5 @@
 ---
-layout: page
 title: Preparing for Operating System Deployment
-permalink: /documentation/confluentosdeploy.html
-toc: true
 ---
 
 If opting to use the confluent OS deployment mechanism, some additional preparation steps are suggested.

--- a/docs/advanced_topics/confluentosdeployment.md
+++ b/docs/advanced_topics/confluentosdeployment.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Confluent OS Deployment and Syslog
-permalink: /documentation/confluentosdeployment.html
 ---
 
 Current and previous users of xCAT may be aware that xCAT configures syslog on deployed systems to do its logging on the xCAT management node instead of the default behavior of logging locally on each system.

--- a/docs/advanced_topics/confluentswitchdisco.md
+++ b/docs/advanced_topics/confluentswitchdisco.md
@@ -1,8 +1,5 @@
 ---
-layout: page
 title: Using switch based discovery
-permalink: /documentation/confluentswitchdisco.html
-toc: true
 ---
 
 Confluent can identify unknown devices based on what network port they are connected to.

--- a/docs/advanced_topics/confluenttoxcat.md
+++ b/docs/advanced_topics/confluenttoxcat.md
@@ -1,8 +1,5 @@
 ---
-layout: page
 title: Using confluent discovery to feed xCAT configuration
-permalink: /documentation/confluenttoxcat.html
-toc: true
 ---
 
 While xCAT has its own discovery mechanism, in some scenarios confluent

--- a/docs/advanced_topics/driverupdatemedia.md
+++ b/docs/advanced_topics/driverupdatemedia.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Using driver update media for RedHat/CentOS
-permalink: /documentation/driverupdatemedia.html
 ---
 
 Occasionally for network deployment of a RHEL or CentOS the modules included in the install initrd for the OS aren’t sufficient to work with the network device being installed over (for example, if the network device is very new and the driver support hasn’t been added to the OS yet).  In that scenario a driver update media package for that network device can be used to provide support for that network device during and after the OS installation.  In order to do that, the following should be done:

--- a/docs/advanced_topics/el7rste.md
+++ b/docs/advanced_topics/el7rste.md
@@ -1,8 +1,5 @@
 ---
-layout: page
 title: Using xCAT to install EL7 on Intel RSTe
-permalink: /documentation/el7rste.html
-toc: true
 ---
 
 # Directing xCAT to install to the RSTe array

--- a/docs/advanced_topics/installxcat_rhel.md
+++ b/docs/advanced_topics/installxcat_rhel.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: xCAT Installation for Red Hat Enterprise Linux 7
-permalink: /documentation/installxcat_rhel.html
 ---
 
 After adding the correct repository as indicated in the [download page](../downloads.md), you can install xCAT by running:

--- a/docs/advanced_topics/installxcat_suse.md
+++ b/docs/advanced_topics/installxcat_suse.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: xCAT Installation for SUSE Linux Enterprise
-permalink: /documentation/installxcat_suse.html
 ---
 
 Note that for SUSE Linux Enterprise 15, the HA module is required to be available for xCAT install to succeed.

--- a/docs/advanced_topics/nodemedia_caveats.md
+++ b/docs/advanced_topics/nodemedia_caveats.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: nodemedia caveats
-permalink: /documentation/nodemedia_caveats.html
 ---
 
 When using the "redfish" hardware management method, the nodemedia attach function

--- a/docs/advanced_topics/remoteconfluent.md
+++ b/docs/advanced_topics/remoteconfluent.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Remote confluent
-permalink: /documentation/remoteconfluent.html
 ---
 
 Note this method for xCAT usage is largely superseded by using a [collective](collective.md) instead,

--- a/docs/advanced_topics/rh8installib.md
+++ b/docs/advanced_topics/rh8installib.md
@@ -1,8 +1,5 @@
 ---
-layout: page
 title: Installing EL8 over InfiniBand
-permalink: /documentation/el8ibinstall.html
-toc: true
 ---
 
 This covers the process of EL8 deployment on a cluster using only InfiniBand.

--- a/docs/advanced_topics/sharedinstallnotes.md
+++ b/docs/advanced_topics/sharedinstallnotes.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Using xCAT management nodes with an NFS-mounted install directory
-permalink: /documentation/sharedinstallnotes.html
 ---
 
 When using an NFS-mounted install directory, installing or updating the xCAT RPMs can result in errors (e.g., lsetfilecon errors) due to some files in the xCAT RPM installing to the install directory and certain filesystem operations not supported on NFS.

--- a/docs/advanced_topics/sharedtftpnotes.md
+++ b/docs/advanced_topics/sharedtftpnotes.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Using xCAT service nodes with a shared tftpboot directory
-permalink: /documentation/sharedtftpnotes.html
 ---
 
 When using a shared tftp directory, the Genesis image generated in an rpm update

--- a/docs/advanced_topics/sle152ibinstall.md
+++ b/docs/advanced_topics/sle152ibinstall.md
@@ -1,8 +1,5 @@
 ---
-layout: page
 title: Installing SLE 15.2 over InfiniBand
-permalink: /documentation/sle152ibinstall.html
-toc: true
 ---
 
 This covers the process of SLE 15.2 deployment on a cluster using only InfiniBand.

--- a/docs/advanced_topics/sles12rste.md
+++ b/docs/advanced_topics/sles12rste.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Using xCAT to install SLES12 on Intel RSTe
-permalink: /documentation/sles12rste.html
 ---
 
 xCAT does not currently consider the RSTe array as a default

--- a/docs/advanced_topics/xcataddingsnmp.md
+++ b/docs/advanced_topics/xcataddingsnmp.md
@@ -1,7 +1,5 @@
 ---
 title: Adding snmp support to xCAT
-layout: page
-permalink: /documentation/xcataddingsnmp.html
 ---
 
 Due to changes in RedHat/CentOS 8, net-snmp-perl is no longer provided in either the vendor repository nor the lenovo repository.

--- a/docs/advanced_topics/xcatconfignotes.md
+++ b/docs/advanced_topics/xcatconfignotes.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: xCAT configuration notes
-permalink: /documentation/xcatconfignotes.html
 ---
 
 * [Installing EL7 with RSTe support](el7rste.md)

--- a/docs/advanced_topics/xcatconfluentsetup.md
+++ b/docs/advanced_topics/xcatconfluentsetup.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Confluent setup in existing xCAT configuration
-permalink: /documentation/configconfluent_xcat.html
 ---
 
 In order to opt into using confluent as your console service, set the site table value for consoleservice:

--- a/docs/advanced_topics/xcatramrootibboot.md
+++ b/docs/advanced_topics/xcatramrootibboot.md
@@ -1,8 +1,7 @@
 ---
-layout: page
 title: Booting xCAT ramroot over InfiniBand
-permalink: /documentation/xcatramrootibboot.html
 ---
+
 In the case of xCAT stateless images which network boot from infiniband, the ordering of the interfaces (ib0, ib1, etc) may change during the booting of the ramroot image. The lower order port (typically comparing MAC address) would normally be assigned the interface name ib0. This example assumes that a static DHCP lease was created for the lower order port.
 
 If the image is configured to boot from the lower order port, the port may instead be assigned the interface name ib1, causing the boot to fail. 

--- a/docs/advanced_topics/xcatstatelessimagesles152.md
+++ b/docs/advanced_topics/xcatstatelessimagesles152.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: xCAT stateless image creation under SLES 15.2 fails
-permalink: /documentation/xcatstatelessimagesles152.html
 ---
 
 During the process of creating an `xCAT stateless image` under `SLES 15.2`, the xCAT genimage command may fail due to failure to locate the software packages in the distribution, even though the software repositories appear to be set up correctly.

--- a/docs/developer/api.md
+++ b/docs/developer/api.md
@@ -22,7 +22,7 @@ to create a local account:
     # confetty create /users/apiuser role=Administrator
 
 With the above example, using 'apiuser' and the entered password in the user/password
-prompt will provide access when accessing the management server by http://servername:14005/.
+prompt will provide access when accessing the management server by http://servername:4005/.
 
 ## **Using python to access the API**
 All of the confluent command lines are implemented in python.  They serve
@@ -48,30 +48,32 @@ scenarios and map more directly to the underlying REST structure, the
 functions `create()`, `read()`, `update()`, and `delete()` are provided.
 See the client.py python API documentation for more details.
 
-<!--
-## /discovery/
+## **Top-level collections**
+
+The root of the API presents the following collections:
+
+| Collection | Purpose |
+|------------|---------|
+| `/nodes/` | All defined nodes and every per-node operation |
+| `/noderange/` | The same per-node structure, applied to a noderange |
+| `/nodegroups/` | Node groups and their attributes |
+| `/users/` | Confluent user accounts |
+| `/usergroups/` | Confluent user groups |
+| `/deployment/` | OS deployment distributions, profiles, and media import |
+| `/discovery/` | Detection and onboarding of new systems |
+| `/networking/` | Switch-derived topology (MAC address tables, LLDP) |
+| `/storage/` | Remote storage/mount management |
+| `/events/` | Alert decoding and event handling |
+| `/staging/` | File upload staging used during deployment |
+| `/version` | The running confluent version |
+| `/uuid` | The confluent collective UUID |
+
+## **The discovery collection: /discovery/**
 
 The discovery collection gathers functionality related to detecting and scanning
-for new systems.
-
-## /discovery/detected/
-
-A collection of systems that have been detected (through scan or otherwise) but
-not yet a node or related to a node.
-
-## /discovery/log
-
-A log of discovery related activity including things being detected and things
-promoting to being a managed node.
-
-## /discovery/scan
-
-A resource to request an active scan.  Generally confluent will scan on startup
-and then passively listen for changes.  This resource can be used to explicitly
-request a scan be performed.  Results from such a scan will appear in the detected/
-collection.
-
--->
+for new systems, and promoting detected systems to managed nodes. Generally
+confluent scans on startup and then passively listens for changes, so detected
+systems appear here automatically as they are found.
 
 ## **API Structure**
 
@@ -283,7 +285,7 @@ the following fields:
             giving up
 * **acknowledge_timeout** - When waiting for an acknowledgement from the target,
                         how long to wait before evaluating the need to retrytime
-* **acknowledge** - Whether to expect an explicit acknowledgement.  For example, SNMP  <!-- Do all of these acronyms make sense? -->
+* **acknowledge** - Whether to expect an explicit acknowledgement.  For example, SNMP
                 traps do not have an SNMP mechanism to acknowledge receipt, so
                 this would be disabled for normal SNMP traps.  However, IPMI
                 PET alerts are SNMP traps, but provide a mechanism a receiver
@@ -352,7 +354,7 @@ Attributes can be accessed via the following groups:
 * **all** - Provides all possible attributes as well as current values
 * **current** - Provides only those attributes that have been given values
 
-When doing UPDATE, 'all' and 'current' will behave identically. The fields are    <!-- What fields? -->
+When doing UPDATE, 'all' and 'current' will behave identically. The fields are
 defined in the [attributes] document.  Each attribute has:
 
 * **value** - The current value of the attribute, after any potential expressions and
@@ -431,8 +433,8 @@ Each event has:
 ### **Decoding alert data: /nodes/[nodename]/events/hardware/decode**
 
 This provides a facility for decoding and enriching alert data from a target.
-For example, an SNMP trap handler can use this to decode a PET alert from an   <!-- Document further. Also what does this mean -->
-IPMI source.  TODO: Document this further                  
+For example, an SNMP trap handler can use this to decode a PET (Platform Event
+Trap) alert originating from an IPMI source into a human-readable event.
 
 
 ### **Managing physical and virtual media: /nodes/[nodename]/media/[argument]**
@@ -444,6 +446,34 @@ Arguments include:
 * **current** - A collection of all uploaded and attached media
 * **uploads** - Manages process of uploading media to management controller for use in OS.
                 Will list current and completed uploads, until told to delete.
-* **attach** - Requests that BMC connect to another server and associate that URL with a media device,   <!-- Arguments needed? -->
+* **attach** - Requests that BMC connect to another server and associate that URL with a media device,
                 instructing BMC to use the file at the URL
 * **detach** - Detaches attached media or deletes an uploaded image or file
+
+
+### **Additional node resources**
+
+The following resources are also available under `/nodes/[nodename]/` and
+`/noderange/[noderange]/`. They map directly to the corresponding client
+commands, which are the most convenient way to explore them.
+
+* **power/inlets** and **power/outlets** - Power distribution unit (PDU) inlets
+  and outlets associated with the node, for environments where confluent manages
+  PDUs alongside servers.
+* **console/graphical**, **console/ikvm**, **console/ikvm_methods**,
+  **console/ikvm_screenshot** - Remote graphical (KVM) console access and a
+  screenshot of the current graphical console, where licensed and supported.
+* **deployment/lock**, **deployment/ident_image**, **deployment/remote_config/run**,
+  **deployment/remote_config/active** - Per-node OS deployment control, including
+  the deployment lock and remotely launched configuration (e.g. Ansible) runs.
+* **configuration/storage/** - Hardware storage controller configuration:
+  `all`, `arrays`, `disks`, and `volumes` for creating and managing RAID arrays
+  and drive usage (see the `nodestorage` command).
+* **configuration/management_controller/licenses** and **.../certificate** -
+  Management controller license installation and TLS certificate signing,
+  CSR generation, and installation (see the `nodelicense` and `nodecertutil`
+  commands).
+* **inventory/firmware/[category]** - In addition to `all`, firmware is broken
+  out into `core`, `adapters`, `disks`, and `misc` categories.
+* **support/servicedata** - Collect vendor service data (support archives) from
+  the node's management controller (see the `nodesupport` command).

--- a/docs/developer/api.md
+++ b/docs/developer/api.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Confluent API Documentation
-permalink: /documentation/developer/api.html
 ---
 
 Confluent models functionality in a hierarchical structure.  It is a RESTful or
@@ -45,10 +43,10 @@ confluent protocol, as described in [remote confluent](../advanced_topics/remote
 
 
 For many common interactions, there is a convenient method on the session
-object called 'simple_noderange_command()'. To accomodate more complex
+object called 'simple_noderange_command()'. To accommodate more complex
 scenarios and map more directly to the underlying REST structure, the
 functions `create()`, `read()`, `update()`, and `delete()` are provided.
-See the client.py python API documentaion for more details.
+See the client.py python API documentation for more details.
 
 <!--
 ## /discovery/
@@ -420,7 +418,7 @@ Each event has:
               the event. For example, "Progress", "Host Power", "Non Auth DIMMs"
 * **component_type** - A description of what type of entity the component is.
                       Examples are: "System Firmware", "Power Unit" and "Memory"
-* **event** - A text description of the event that occured
+* **event** - A text description of the event that occurred
 * **id** - A numerical value representing the id, useful for looking up the id
        against a database
 * **record_id** - An identifier associated with the event by the providing device 

--- a/docs/getting_started/.nav.yml
+++ b/docs/getting_started/.nav.yml
@@ -1,9 +1,9 @@
 nav:
   - confluentquickstart_el8.md
-  - confluentgroups.md
   - installconfluent_rhel.md
   - installconfluent_ubuntu.md
   - installconfluent_suse.md
   - configureconfluent.md
+  - confluentgroups.md
   - ibinstallconfluentrhel8.md
   - ibinstallconfluentsle152.md

--- a/docs/getting_started/configureconfluent.md
+++ b/docs/getting_started/configureconfluent.md
@@ -1,8 +1,5 @@
 ---
-layout: page
 title: Configuring confluent
-permalink: /documentation/configconfluent.html
-toc: true
 ---
 
 ## When used in conjunction with xCAT

--- a/docs/getting_started/confluentgroups.md
+++ b/docs/getting_started/confluentgroups.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Confluent Groups
-permalink: /documentation/confluentgroups.html
 ---
 
 In confluent, there is a concept of node groups to provide convenient shorthand for noderanges as well as 
@@ -15,7 +13,9 @@ Node groups can be used the same as nodes in [noderange syntax](../manuals/noder
 Additionally, a group can be used to be shorthand for a noderange.  For example, to make a group `all` to represent every node
 excluding `switches` and `pdus`, without having to continually update the `all` group as nodes are added or removed:
 
-    nodegroupdefine all noderange=everything,-switches,-pdus
+```bash
+nodegroupdefine all noderange=everything,-switches,-pdus
+```
 
 Note that `noderange` groups do not contribute to providing attributes to the node attributes.
 
@@ -44,53 +44,67 @@ Now a sample will be presented leveraging groups to define a representative conf
 First will set the 'global' username and password that is preferred in this site.  This will use the interactive prompt to
 keep the values out of the shell history and ps output for other users.
 
-    # nodegroupattrib everything -p secret.hardwaremanagementuser secret.hardwaremanagementpassword
-    Enter value for secret.hardwaremanagementuser:
-    Confirm value for secret.hardwaremanagementuser:
-    Enter value for secret.hardwaremanagementpassword:
-    Confirm value for secret.hardwaremanagementpassword:
-    everything: secret.hardwaremanagementpassword: ********
-    everything: secret.hardwaremanagementuser: ********
+```bash
+# nodegroupattrib everything -p secret.hardwaremanagementuser secret.hardwaremanagementpassword
+Enter value for secret.hardwaremanagementuser:
+Confirm value for secret.hardwaremanagementuser:
+Enter value for secret.hardwaremanagementpassword:
+Confirm value for secret.hardwaremanagementpassword:
+everything: secret.hardwaremanagementpassword: ********
+everything: secret.hardwaremanagementuser: ********
+```
 
 A group will be created to explain the configurations naming scheme and how it influences network connectivity:
 
-    # nodegroupdefine rackmount location.rack={n1} location.u={n2} \
-      net.switch=r{location.rack}eth net.switchport=swp{location.u} \
-      discovery.nodeconfig=bmc.ipv4_address=172.30.{location.rack}.{location.u} \
-      discovery.policy=permissive \
-      power.outlet='{(n2-1)%12+1}' power.pdu=r{n1}pdu'{(n2-1)/12+1}'
+```bash
+# nodegroupdefine rackmount location.rack={n1} location.u={n2} \
+  net.switch=r{location.rack}eth net.switchport=swp{location.u} \
+  discovery.nodeconfig=bmc.ipv4_address=172.30.{location.rack}.{location.u} \
+  discovery.policy=permissive \
+  power.outlet='{(n2-1)%12+1}' power.pdu=r{n1}pdu'{(n2-1)/12+1}'
+```
 
 A group will be created to declare the method to manage how to manage pdus:
 
-    # nodegroupdefine pdus hardwaremanagement.method=geist
+```bash
+# nodegroupdefine pdus hardwaremanagement.method=geist
+```
 
 A group to explain method to manage ethernet switches:
 
-    # nodegroupdefine switches hardwaremanagement.method=affluent
+```bash
+# nodegroupdefine switches hardwaremanagement.method=affluent
+```
 
 A group to have a shorthand for all server devices excluding infrastructure equipment when using noderanges:
 
-    # nodegroupdefine all noderange=everything,-pdus,-switches
+```bash
+# nodegroupdefine all noderange=everything,-pdus,-switches
+```
 
 Then define nodes according to what is expected for an eight rack configuration with 42 1U servers each:
 
-    # nodedefine r[1:8]eth groups=switches
-    # nodedefine r[1:8]pdu[1:4] groups=pdus
-    # nodedefine r[1:8]u[1:42] groups=rackmount
+```bash
+# nodedefine r[1:8]eth groups=switches
+# nodedefine r[1:8]pdu[1:4] groups=pdus
+# nodedefine r[1:8]u[1:42] groups=rackmount
+```
 
 With this in place, `nodeattrib --blame` can be used to see the results of the sequence of commands:
 
-    # nodeattrib r3u32 --blame
-    r3u32: discovery.nodeconfig: bmc.ipv4_address=172.30.3.32 (inherited from group rackmount, derived from expression "bmc.ipv4_address=172.30.{location.rack}.{location.u}")
-    r3u32: discovery.policy: permissive (inherited from group rackmount)
-    r3u32: groups: rackmount,everything
-    r3u32: location.rack: 3 (inherited from group rackmount, derived from expression "{n1}")
-    r3u32: location.u: 32 (inherited from group rackmount, derived from expression "{n2}")
-    r3u32: net.switch: r3eth (inherited from group rackmount, derived from expression "r{location.rack}eth")
-    r3u32: net.switchport: swp32 (inherited from group rackmount, derived from expression "swp{location.u}")
-    r3u32: power.outlet: 8 (inherited from group rackmount, derived from expression "{(n2-1)%12+1}")
-    r3u32: power.pdu: r3pdu3 (inherited from group rackmount, derived from expression "r{n1}pdu{(n2-1)/12+1}")
-    r3u32: secret.hardwaremanagementpassword: ******** (inherited from group everything)
-    r3u32: secret.hardwaremanagementuser: ******** (inherited from group everything)
+```bash
+# nodeattrib r3u32 --blame
+r3u32: discovery.nodeconfig: bmc.ipv4_address=172.30.3.32 (inherited from group rackmount, derived from expression "bmc.ipv4_address=172.30.{location.rack}.{location.u}")
+r3u32: discovery.policy: permissive (inherited from group rackmount)
+r3u32: groups: rackmount,everything
+r3u32: location.rack: 3 (inherited from group rackmount, derived from expression "{n1}")
+r3u32: location.u: 32 (inherited from group rackmount, derived from expression "{n2}")
+r3u32: net.switch: r3eth (inherited from group rackmount, derived from expression "r{location.rack}eth")
+r3u32: net.switchport: swp32 (inherited from group rackmount, derived from expression "swp{location.u}")
+r3u32: power.outlet: 8 (inherited from group rackmount, derived from expression "{(n2-1)%12+1}")
+r3u32: power.pdu: r3pdu3 (inherited from group rackmount, derived from expression "r{n1}pdu{(n2-1)/12+1}")
+r3u32: secret.hardwaremanagementpassword: ******** (inherited from group everything)
+r3u32: secret.hardwaremanagementuser: ******** (inherited from group everything)
+```
 
 

--- a/docs/getting_started/confluentquickstart_el8.md
+++ b/docs/getting_started/confluentquickstart_el8.md
@@ -1,8 +1,5 @@
 ---
-layout: page
 title: Confluent quickstart
-permalink: /documentation/confluentquickstart_el8.html
-toc: true
 ---
 
 This document provides one example flow from installation to capable cluster. Confluent is very flexible and there are
@@ -14,10 +11,12 @@ documentation for more detail and alternative strategies for particular areas.
 
 To install confluent as well as optional requirements, after adding a yum repository according to [download page](../downloads.md):
 
-    # yum install lenovo-confluent tftp-server
-    # systemctl enable confluent --now
-    # systemctl enable httpd --now # if wanting to deploy operating systems and/or the web gui
-    # systemctl enable tftp.socket --now  # If wanting to support PXE install
+```bash
+# yum install lenovo-confluent tftp-server
+# systemctl enable confluent --now
+# systemctl enable httpd --now # if wanting to deploy operating systems and/or the web gui
+# systemctl enable tftp.socket --now  # If wanting to support PXE install
+```
 
 More details, including firewall rules and enabling GUI login may be found in the dedicated install page.
 
@@ -28,28 +27,32 @@ called 'everything` is automatically added to every node. It provides a method t
 
 Attributes may all be specified on the command line, and an example set could be:
 
-    # nodegroupattrib everything deployment.useinsecureprotocols=firmware console.method=ipmi dns.servers=172.30.0.254 dns.domain=mydomain.example net.ipv4_gateway=172.30.0.254
+```bash
+# nodegroupattrib everything deployment.useinsecureprotocols=firmware console.method=ipmi dns.servers=172.30.0.254 dns.domain=mydomain.example net.ipv4_gateway=172.30.0.254
+```
 
 
 The deployment.useinsecureprotocols=firmware enables PXE support (HTTPS only mode is by default the only allowed mode), console.method=ipmi may be skipped but if specified instructs
-confluennt to use IPMI to access the text console to enable the `nodeconsole` command.
+confluent to use IPMI to access the text console to enable the `nodeconsole` command.
 
 While passwords and similar may be specified the same way, it is recommended to use the '-p' argument to prompt for values, to keep them out of your command history. Note that if
 unspecified, default root password behavior is to disable password based login and for grub omitting the password will allow console to edit grub at boot without a password:
 
-    # nodegroupattrib everything -p bmcuser bmcpass crypted.rootpassword crypted.grubpassword
-    Enter value for bmcuser: 
-    Confirm value for bmcuser: 
-    Enter value for bmcpass: 
-    Confirm value for bmcpass: 
-    Enter value for crypted.rootpassword: 
-    Confirm value for crypted.rootpassword: 
-    Enter value for crypted.grubpassword: 
-    Confirm value for crypted.grubpassword: 
-    everything: crypted.grubpassword: ********
-    everything: crypted.rootpassword: ********
-    everything: secret.hardwaremanagementpassword: ********
-    everything: secret.hardwaremanagementuser: ********
+```bash
+# nodegroupattrib everything -p bmcuser bmcpass crypted.rootpassword crypted.grubpassword
+Enter value for bmcuser: 
+Confirm value for bmcuser: 
+Enter value for bmcpass: 
+Confirm value for bmcpass: 
+Enter value for crypted.rootpassword: 
+Confirm value for crypted.rootpassword: 
+Enter value for crypted.grubpassword: 
+Confirm value for crypted.grubpassword: 
+everything: crypted.grubpassword: ********
+everything: crypted.rootpassword: ********
+everything: secret.hardwaremanagementpassword: ********
+everything: secret.hardwaremanagementuser: ********
+```
 
 # Leave IPv6 enabled
 
@@ -63,7 +66,9 @@ fe80::
 Nodes may contain any number of attributes. In this document, everything is defined at the group level, so we only need define the names. Here we
 will use a simple n[number] scheme, though any scheme may be used.
 
-    # nodedefine n1-n4 
+```bash
+# nodedefine n1-n4 
+```
 
 
 # Establishing hardware management through confluent discovery
@@ -75,53 +80,63 @@ For this guide we will use the manual confluent discovery process, which works w
 
 A command to examine what was detected:
     
-    # nodediscover rescan
-    Rescan complete
-    # nodediscover list -t lenovo-xcc -f node,model,serial,mac -o model 
-     Node|      Model|   Serial|               Mac
-    -----|-----------|---------|------------------
-         | 7D2VCTO1WW| J301VETT| 08:94:ef:aa:93:b7
-         | 7X21CTO1WW| J100M79E| 08:94:ef:41:01:b5
-         | 7X21CTO1WW| J1001PNE| 08:94:ef:50:1c:6b
-         | 7X21CTO1WW| J1001PNG| 08:94:ef:50:9b:3b
-         | 7X2104Z000| DVJJ1042| 08:94:ef:3f:e0:af
-         | 7X2104Z000| DVJJ1003| 08:94:ef:40:89:31
-         | 7X2104Z023| DVJJ9986| 08:94:ef:2f:2b:c7
-         | 7X2106Z009| DVJJ1086| 08:94:ef:2f:2e:9d
-         | 7Y02RCZ000| DVJJ8699| 08:94:ef:49:c3:55
+```bash
+# nodediscover rescan
+Rescan complete
+# nodediscover list -t lenovo-xcc -f node,model,serial,mac -o model 
+ Node|      Model|   Serial|               Mac
+-----|-----------|---------|------------------
+     | 7D2VCTO1WW| J301VETT| 08:94:ef:aa:93:b7
+     | 7X21CTO1WW| J100M79E| 08:94:ef:41:01:b5
+     | 7X21CTO1WW| J1001PNE| 08:94:ef:50:1c:6b
+     | 7X21CTO1WW| J1001PNG| 08:94:ef:50:9b:3b
+     | 7X2104Z000| DVJJ1042| 08:94:ef:3f:e0:af
+     | 7X2104Z000| DVJJ1003| 08:94:ef:40:89:31
+     | 7X2104Z023| DVJJ9986| 08:94:ef:2f:2b:c7
+     | 7X2106Z009| DVJJ1086| 08:94:ef:2f:2e:9d
+     | 7Y02RCZ000| DVJJ8699| 08:94:ef:49:c3:55
+```
 
 This can be used to create a .csv file for manual discovery input:
 
-    # nodediscover list -t lenovo-xcc -f node,serial -c -o model > input.csv
+```bash
+# nodediscover list -t lenovo-xcc -f node,serial -c -o model > input.csv
+```
 
 After manually editing in the desired names and deleting rows not of interest, input.csv looks like:
 
-    # cat input.csv
-    Node,Serial
-    n1,J100M79E
-    n2,J301VETT
-    n3,J1001PNE
-    n4,J1001PNG
+```bash
+# cat input.csv
+Node,Serial
+n1,J100M79E
+n2,J301VETT
+n3,J1001PNE
+n4,J1001PNG
+```
 
 Which can then be passed to nodediscover assign:
 
-    # nodediscover assign -i input.csv 
-    Defined n1
-    Discovered n1
-    Defined n2
-    Discovered n2
-    Defined n3
-    Discovered n3
-    Defined n4
-    Discovered n4
+```bash
+# nodediscover assign -i input.csv 
+Defined n1
+Discovered n1
+Defined n2
+Discovered n2
+Defined n3
+Discovered n3
+Defined n4
+Discovered n4
+```
 
 At which point we can demonstrate power control through the everything group:
 
-    # nodepower everything
-    n1: on
-    n2: on
-    n3: on
-    n4: off
+```bash
+# nodepower everything
+n1: on
+n2: on
+n3: on
+n4: off
+```
 
 # Preparing for OS deployment
 
@@ -133,20 +148,26 @@ Note that no particular name resolution solution is required, but this document 
 
 We start by building /etc/hosts. This may be done manually, or noderun can be used to quickly generate lines for /etc/hosts. First a dry run to make sure it looks correct:
 
-    # noderun -n n1-n4 echo 172.30.0.{n1} {node} {node}.{dns.domain}
-    172.30.0.1 n1 n1.mydomain.example
-    172.30.0.2 n2 n2.mydomain.example
-    172.30.0.3 n3 n3.mydomain.example
-    172.30.0.4 n4 n4.mydomain.example
+```bash
+# noderun -n n1-n4 echo 172.30.0.{n1} {node} {node}.{dns.domain}
+172.30.0.1 n1 n1.mydomain.example
+172.30.0.2 n2 n2.mydomain.example
+172.30.0.3 n3 n3.mydomain.example
+172.30.0.4 n4 n4.mydomain.example
+```
 
 And then append to /etc/hosts when it looks correct:
 
-    # noderun -n n1-n4 echo 172.30.0.{n1} {node} {node}.{dns.domain} >> /etc/hosts
+```bash
+# noderun -n n1-n4 echo 172.30.0.{n1} {node} {node}.{dns.domain} >> /etc/hosts
+```
 
 Finally, to quickly have a dns server, installing and starting dnsmasq can make /etc/hosts available through dns:
 
-    # yum install dnsmasq
-    # systemctl enable dnsmasq --now
+```bash
+# yum install dnsmasq
+# systemctl enable dnsmasq --now
+```
 
 Any time /etc/hosts is updated, restart dnsmasq to have it pick up changes.
 
@@ -194,10 +215,12 @@ Site initramfs content packed successfully
 
 The iso of a supported OS may be imported by using the `osdeploy import` command, for example:
 
-    # osdeploy import RHEL-8.2.0-20200404.0-x86_64-dvd1.iso 
-    Importing from /root/RHEL-8.2.0-20200404.0-x86_64-dvd1.iso to /var/lib/confluent/distributions/rhel-8.2-x86_64
-    complete: 100.00%    
-    Deployment profile created: rhel-8.2-x86_64-default
+```bash
+# osdeploy import RHEL-8.2.0-20200404.0-x86_64-dvd1.iso 
+Importing from /root/RHEL-8.2.0-20200404.0-x86_64-dvd1.iso to /var/lib/confluent/distributions/rhel-8.2-x86_64
+complete: 100.00%    
+Deployment profile created: rhel-8.2-x86_64-default
+```
 
 Note that a new directory exists in /var/lib/confluent/public/os/rhel-8.2-x86_64-default. This is intended to be freely editable for customization
 as desired.
@@ -206,38 +229,50 @@ as desired.
 
 To initiate network deployment of the profile above, the nodedeploy command may be used (TIP: the profile name like many other things may be tab completed when used interactively):
 
-    # nodedeploy n1-n2 -n rhel-8.2-x86_64-default 
-    n1: network
-    n2: network
-    n1: reset
-    n2: reset
+```bash
+# nodedeploy n1-n2 -n rhel-8.2-x86_64-default 
+n1: network
+n2: network
+n1: reset
+n2: reset
+```
 
 At this point, the boot and install progress may be watched interactively through the video console or by the text console available via nodeconsole:
 
-    # nodeconsole n1
+```bash
+# nodeconsole n1
+```
 
 Also `nodedeploy` may be used to check the current status of a deployment:
 
-    # nodedeploy n1-n2
-    n1: pending: centos-8.2-x86_64-default (node authentication armed)
-    n2: pending: centos-8.2-x86_64-default (node authentication armed)
+```bash
+# nodedeploy n1-n2
+n1: pending: centos-8.2-x86_64-default (node authentication armed)
+n2: pending: centos-8.2-x86_64-default (node authentication armed)
+```
 
 When install is complete:
 
-    [root@mgt1 ~]# nodedeploy d3,d4
-    n1: completed: centos-8.2-x86_64-default
-    n2: completed: centos-8.2-x86_64-default
+```bash
+[root@mgt1 ~]# nodedeploy d3,d4
+n1: completed: centos-8.2-x86_64-default
+n2: completed: centos-8.2-x86_64-default
+```
 
 Additionally, ssh to nodes will work:
 
-    # nodeshell n1,n2 echo test
-    n1: test
-    n2: test
+```bash
+# nodeshell n1,n2 echo test
+n1: test
+n2: test
+```
 
 As will ssh between nodes:
 
-    # ssh n1 ssh n2 echo test
-    test
+```bash
+# ssh n1 ssh n2 echo test
+test
+```
 
 
 

--- a/docs/getting_started/ibinstallconfluentrhel8.md
+++ b/docs/getting_started/ibinstallconfluentrhel8.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: InfiniBand install with confluent on RHEL 8
-permalink: /documentation/ibinstallconfluentrhel8.html
 ---
 
 Please refer to the following link for the confluent OS deployment process:
@@ -35,19 +33,25 @@ Net config fixup postscript
 InfiniBand network configuration does not work as expected out of the box.  If not installing Mellanox OFED, the following is an example of a
 postscript that can be added to correct that behavior:
 
-    # cat /var/lib/confluent/public/os/your-profile-here/scripts/pod.d/fixipoib
-    echo 'install mlx5_core /sbin/modprobe --ignore-install mlx5_core; /sbin/modprobe mlx5_ib; /sbin/modprobe ib_ipoib' >> /etc/modprobe.d/mlx.conf
-    echo 'add_drivers+="mlx5_ib ib_ipoib"' > /etc/dracut.conf.d/mlx.conf
-    dracut -f
+```bash
+# cat /var/lib/confluent/public/os/your-profile-here/scripts/pod.d/fixipoib
+echo 'install mlx5_core /sbin/modprobe --ignore-install mlx5_core; /sbin/modprobe mlx5_ib; /sbin/modprobe ib_ipoib' >> /etc/modprobe.d/mlx.conf
+echo 'add_drivers+="mlx5_ib ib_ipoib"' > /etc/dracut.conf.d/mlx.conf
+dracut -f
+```
 
 Kernel command line configuration
 
 Change the profile.yaml file in the the OS profile to be deployed to add:
 
-    # rd.driver.pre="mlx5_ib,ib_ipoib"
+```bash
+# rd.driver.pre="mlx5_ib,ib_ipoib"
+```
 
 on the kernel.args line
 
 Then run
 
-    # osdeploy updateboot <OS profile name>
+```bash
+# osdeploy updateboot <OS profile name>
+```

--- a/docs/getting_started/ibinstallconfluentsle152.md
+++ b/docs/getting_started/ibinstallconfluentsle152.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: InfiniBand install with confluent on SLE 15.2
-permalink: /documentation/ibinstallconfluentsle152.html
 ---
 
 Please refer to the following link for the confluent OS deployment process:
@@ -15,17 +13,23 @@ Net config fixup postscript
 InfiniBand network configuration does not work as expected out of the box.  If not installing Mellanox OFED, the following is an example of a
 postscript that can be added to correct that behavior:
 
-    # cat /install/postscripts/fixipoib
-    echo 'install mlx5_core /sbin/modprobe --ignore-install mlx5_core; /sbin/modprobe mlx5_ib; /sbin/modprobe ib_ipoib' >> /<profile dir>/scripts/post.d/mlx.conf
-    echo 'add_drivers+="mlx5_ib ib_ipoib"' > /<profile dir>/scripts/post.d/mlx.conf
-    dracut -f
+```bash
+# cat /install/postscripts/fixipoib
+echo 'install mlx5_core /sbin/modprobe --ignore-install mlx5_core; /sbin/modprobe mlx5_ib; /sbin/modprobe ib_ipoib' >> /<profile dir>/scripts/post.d/mlx.conf
+echo 'add_drivers+="mlx5_ib ib_ipoib"' > /<profile dir>/scripts/post.d/mlx.conf
+dracut -f
+```
 
 Kernel command line configuration
 
 Change the profile.yaml file in the the OS profile to be deployed to add:
 
-    # insmod="ib_ipoib"
+```bash
+# insmod="ib_ipoib"
+```
 
 and run
 
-    # osdeploy updateboot <OS profile name>
+```bash
+# osdeploy updateboot <OS profile name>
+```

--- a/docs/getting_started/installconfluent_rhel.md
+++ b/docs/getting_started/installconfluent_rhel.md
@@ -1,86 +1,109 @@
 ---
-layout: page
 title: Confluent Installation for Red Hat Enterprise Linux
-permalink: /documentation/installconfluent_rhel.html
-toc: true
 ---
 
 Enterprise Linux 8.6, 9.0, or 10.0 and higher is required for installation.
 
 First add the Lenovo HPC yum repository appropriate to your environment according to the procedure on the  [download page](../downloads.md).  It is suggested to then make sure there are no updates in the repository for your existing software:
 
-    yum --disablerepo=* --enablerepo=lenovo-hpc update
+```bash
+yum --disablerepo=* --enablerepo=lenovo-hpc update
+```
 
 At this point, the package may be installed:
 
-    yum install lenovo-confluent
+```bash
+yum install lenovo-confluent
+```
 
 Next, enable it and start the confluent service:
 
-    systemctl enable confluent --now
+```bash
+systemctl enable confluent --now
+```
 
 At this point, source the script below for confluent command line functionality or logout and log back in. 
 
-    source /etc/profile.d/confluent_env.sh
+```bash
+source /etc/profile.d/confluent_env.sh
+```
 
 # Enabling http connectivity for OS Deployment, REST API usage, and the Web UI
 
 If you have SELinux enforcing, you need to allow httpd to make network
 connections:
 
-    setsebool -P httpd_can_network_connect=on
+```bash
+setsebool -P httpd_can_network_connect=on
+```
 
 Note that a default install also will have firewall restrictions preventing
 https use.  You may remedy this by doing the following:
 
-    firewall-cmd --zone=public --add-service=https --permanent
-    firewall-cmd --zone=public --add-service=https
+```bash
+firewall-cmd --zone=public --add-service=https --permanent
+firewall-cmd --zone=public --add-service=https
+```
 
 Further, OS deployment uses some more ports, depending on scenario.  
 
 If doing any sort of network based boot (PXE/HTTP) without using an 'identity image' mounted over virtual USB, then the following is required to facilitate the API arming mechanism, as
 well as the SSDP port (udp port 1900) to allow deploying systems to scan for confluent servers:
 
-    firewall-cmd --permanent --zone=public --add-port=13001/tcp
-    firewall-cmd --permanent --zone=public --add-port=1900/udp
+```bash
+firewall-cmd --permanent --zone=public --add-port=13001/tcp
+firewall-cmd --permanent --zone=public --add-port=1900/udp
+```
 
 If doing HTTP boot with `deployment.useinsecureprotocols' set to firmware, you will need plain http (port 80):
 
-    firewall-cmd --permanent --zone=public --add-service=http --permanent
-    firewall-cmd --permanent --zone=public --add-service=http
+```bash
+firewall-cmd --permanent --zone=public --add-service=http --permanent
+firewall-cmd --permanent --zone=public --add-service=http
+```
 
 If doing PXE boot, then you will need PXE and TFTP opened:
 
-    firewall-cmd --permanent --zone=public --add-port=67/udp
-    firewall-cmd --permanent --zone=public --add-port=69/udp
-    firewall-cmd --permanent --zone=public --add-port=4011/udp
+```bash
+firewall-cmd --permanent --zone=public --add-port=67/udp
+firewall-cmd --permanent --zone=public --add-port=69/udp
+firewall-cmd --permanent --zone=public --add-port=4011/udp
+```
 
 Further, if doing network boot over IPv6:
 
-    firewall-cmd --permanent --zone=public --add-port=547/udp
+```bash
+firewall-cmd --permanent --zone=public --add-port=547/udp
+```
 
 
 
 If the web server is not already started, enable the web server:
 
-    systemctl enable httpd --now
+```bash
+systemctl enable httpd --now
+```
 
 
-If wanting to use nginx instead of Apache, then see this [document](../advanced_topics/switchtonginx) for details.
+If wanting to use nginx instead of Apache, then see this [document](../advanced_topics/switchtonginx.md) for details.
 
 # Web UI Forwarding feature
 
 The WebUI offers dynamic port forwarding.  To enable this feature, ensure TCP ports starting from port 3900 through however many ports you anticipate concurrently using.
 Otherwise, you may opt to disable the firewall:
 
-    systemctl stop firewalld
-    systemctl disable firewalld
+```bash
+systemctl stop firewalld
+systemctl disable firewalld
+```
 
 # Web UI Login
 
 In terms of confluent itself, it is by default set up without any user access.  To enable a user that can ssh into your server to access the web interface:
 
-    confetty create /users/demouser role=admin
+```bash
+confetty create /users/demouser role=admin
+```
 
 The user 'demouser' may now use his login password to access the confluent web interface as an administrator.  The available roles are:
 
@@ -90,7 +113,9 @@ The user 'demouser' may now use his login password to access the confluent web i
 
 After these steps, the GUI should be available at:
 
-    https://[server]/lenovo-confluent/
+```bash
+https://[server]/lenovo-confluent/
+```
 
 
 # Preparing for discovery if firewall enabled
@@ -99,19 +124,21 @@ If wanting to use the confluent discovery capabilities and you have a firewall e
 is required. First, check /etc/firewalld/firewalld.conf and ensure that the FirewallBackend is set to iptables,
 as the multicast reply rules require it.  With that configured, here are example commands to allow discovery to work when managed by firewalld:
 
-    firewall-cmd --permanent --new-ipset=confluentv4 --type=hash:ip,port --option timeout=3
-    firewall-cmd --permanent --new-ipset=confluentv6 --type=hash:ip,port --option timeout=3 --family inet6
-    firewall-cmd --reload
-    firewall-cmd --permanent --direct --add-rule ipv6 filter OUTPUT 1 -p udp -m udp --dport 427 -j SET --add-set confluentv6 src,src --exist
-    firewall-cmd --permanent --direct --add-rule ipv4 filter OUTPUT 1 -p udp -m udp --dport 427 -j SET --add-set confluentv4 src,src --exist
-    firewall-cmd --permanent --direct --add-rule ipv6 filter OUTPUT 1 -p udp -m udp --dport 1900 -j SET --add-set confluentv6 src,src --exist
-    firewall-cmd --permanent --direct --add-rule ipv4 filter OUTPUT 1 -p udp -m udp --dport 1900 -j SET --add-set confluentv4 src,src --exist
-    firewall-cmd --permanent --direct --add-rule ipv4 filter INPUT 1 -p udp -m set --match-set confluentv4 dst,dst -j ACCEPT
-    firewall-cmd --permanent --direct --add-rule ipv6 filter INPUT 1 -p udp -m set --match-set confluentv6 dst,dst -j ACCEPT
-    firewall-cmd --zone=public --add-port=427/udp --permanent
-    firewall-cmd --zone=public --add-port=1900/udp --permanent
-    firewall-cmd --zone=public --add-service=dhcp --permanent
-    firewall-cmd --reload
+```bash
+firewall-cmd --permanent --new-ipset=confluentv4 --type=hash:ip,port --option timeout=3
+firewall-cmd --permanent --new-ipset=confluentv6 --type=hash:ip,port --option timeout=3 --family inet6
+firewall-cmd --reload
+firewall-cmd --permanent --direct --add-rule ipv6 filter OUTPUT 1 -p udp -m udp --dport 427 -j SET --add-set confluentv6 src,src --exist
+firewall-cmd --permanent --direct --add-rule ipv4 filter OUTPUT 1 -p udp -m udp --dport 427 -j SET --add-set confluentv4 src,src --exist
+firewall-cmd --permanent --direct --add-rule ipv6 filter OUTPUT 1 -p udp -m udp --dport 1900 -j SET --add-set confluentv6 src,src --exist
+firewall-cmd --permanent --direct --add-rule ipv4 filter OUTPUT 1 -p udp -m udp --dport 1900 -j SET --add-set confluentv4 src,src --exist
+firewall-cmd --permanent --direct --add-rule ipv4 filter INPUT 1 -p udp -m set --match-set confluentv4 dst,dst -j ACCEPT
+firewall-cmd --permanent --direct --add-rule ipv6 filter INPUT 1 -p udp -m set --match-set confluentv6 dst,dst -j ACCEPT
+firewall-cmd --zone=public --add-port=427/udp --permanent
+firewall-cmd --zone=public --add-port=1900/udp --permanent
+firewall-cmd --zone=public --add-service=dhcp --permanent
+firewall-cmd --reload
+```
 
 
 # Getting ready to use confluent

--- a/docs/getting_started/installconfluent_suse.md
+++ b/docs/getting_started/installconfluent_suse.md
@@ -1,23 +1,26 @@
 ---
-layout: page
 title: Confluent Installation for SUSE Linux Enterprise
-permalink: /documentation/installconfluent_suse.html
-toc: true
 ---
 
 SuSE Linux Enterprise 15 SP4 or higher is currently required for installation.
 
 After adding the correct repository as indicated in the [download page](../downloads.md), you can install confluent by doing:
 
-    zypper install lenovo-confluent
+```bash
+zypper install lenovo-confluent
+```
 
 At which point go ahead and enable it and start it.
 
-    systemctl enable confluent --now
+```bash
+systemctl enable confluent --now
+```
 
 At this point, source the script below for confluent command line functionality or logout and log back in. 
 
-    source /etc/profile.d/confluent_env.sh
+```bash
+source /etc/profile.d/confluent_env.sh
+```
 
 
 ## Enabling the Web UI
@@ -26,23 +29,31 @@ At this point, source the script below for confluent command line functionality 
 
 If not otherwise enabling and configuring TLS, then the following will activate a TLS configuration:	
 
-    cd /etc/apache2/vhosts.d/
-    cp vhost-ssl.template mySSL.conf 
+```bash
+cd /etc/apache2/vhosts.d/
+cp vhost-ssl.template mySSL.conf 
+```
 
 Use osdeploy to create TLS certificate:
 
-    osdeploy initialize -t
+```bash
+osdeploy initialize -t
+```
 
 Enable SSL on Apache
 
-    a2enmod rewrite
-    a2enflag SSL
-    systemctl enable apache2 --now
+```bash
+a2enmod rewrite
+a2enflag SSL
+systemctl enable apache2 --now
+```
 
 
 In terms of confluent itself, it is by default set up without any user access.  To enable a user that can ssh into your server to access the web interface:
 
-    confetty create /users/demouser role=admin
+```bash
+confetty create /users/demouser role=admin
+```
 
 The user 'demouser' may now use his login password to access the confluent web interface as an administrator.  The available roles are:
 
@@ -53,7 +64,9 @@ The user 'demouser' may now use his login password to access the confluent web i
 
 After these steps, the GUI should be available at:
 
-    https://[server]/lenovo-confluent/
+```bash
+https://[server]/lenovo-confluent/
+```
 
 # Getting ready to use confluent
  

--- a/docs/getting_started/installconfluent_ubuntu.md
+++ b/docs/getting_started/installconfluent_ubuntu.md
@@ -1,23 +1,26 @@
 ---
-layout: page
 title: Confluent Installation for Ubuntu
-permalink: /documentation/installconfluent_ubuntu.html
-toc: true
 ---
 
 Ubuntu Linux 22.04 or 24.04 is supported for installation.
 
 After adding the correct repository as indicated in the [download page](../downloads.md), you can install confluent by doing:
 
-    apt install lenovo-confluent
+```bash
+apt install lenovo-confluent
+```
 
 At which point go ahead and enable it and start it.
 
-    systemctl enable confluent --now
+```bash
+systemctl enable confluent --now
+```
 
 At this point, source the script below for confluent command line functionality or logout and log back in. 
 
-    source /etc/profile.d/confluent_env.sh
+```bash
+source /etc/profile.d/confluent_env.sh
+```
 
 
 ## Enabling support for PXE
@@ -25,7 +28,9 @@ At this point, source the script below for confluent command line functionality 
 Prior to running osdeploy, it is suggested to install a tftp server.  The following will install a tftp server
 with socket activation, which is generally adequate:
 
-    apt install tftpd-hpa
+```bash
+apt install tftpd-hpa
+```
 
 
 
@@ -35,20 +40,28 @@ with socket activation, which is generally adequate:
 
 If not otherwise enabling and configuring TLS, then the following will activate a TLS configuration:	
 
-    a2enmod ssl
-    a2ensite default-ssl.conf
+```bash
+a2enmod ssl
+a2ensite default-ssl.conf
+```
 
 Also, enable the confluent web configuration:
 
-    a2enconf confluent
+```bash
+a2enconf confluent
+```
 
 Use osdeploy to create TLS certificate:
 
-    osdeploy initialize -t
+```bash
+osdeploy initialize -t
+```
 
 In terms of confluent itself, it is by default set up without any user access.  To enable a user that can ssh into your server to access the web interface:
 
-    confetty create /users/demouser role=admin
+```bash
+confetty create /users/demouser role=admin
+```
 
 The user 'demouser' may now use his login password to access the confluent web interface as an administrator.  The available roles are:
 
@@ -59,7 +72,9 @@ The user 'demouser' may now use his login password to access the confluent web i
 
 After these steps, the GUI should be available at:
 
-    https://[server]/lenovo-confluent/
+```bash
+https://[server]/lenovo-confluent/
+```
 
 # Getting ready to use confluent
  

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,61 +1,152 @@
-# Home
+---
+title: Home
+---
 
-## Confluent
+# Confluent
 
-Confluent is a software package to handle essential bootstrap and operation of scale-out
-server configurations. It incorporates a variety of functions relevant to that end:
+Confluent handles the essential bootstrap and day-to-day operation of scale-out
+server configurations. It deploys operating systems, controls hardware, manages
+consoles, gathers telemetry, and onboards new devices across clusters ranging
+from a handful of nodes to many thousands.
 
-## Features
+Confluent is the modern successor of [xCAT](https://github.com/xcat2/xcat-core).
+If you are coming from xCAT, see
+[Confluent vs. xCAT](miscellaneous/confluentvxcat.md).
 
-* Console Management
-    * Arbitrate multi-user access
-    * Full logging with fine grained timestamps
-    * VT-aware buffering for quality reconstitution of a console after reconnect
-* Hardware Control: Essential operations using ipmi, redfish, and/or implementation specific plugins to implement features including:
-    * Power on/off
-    * Set next boot device (e.g. force network boot)
-    * Configure BIOS/UEFI/BMC settings
-    * Configure hardware storage controllers (e.g. create/delete raid arrays and set drive usage)
-    * Health check
-    * Telemetry (temperature, voltages, power, energy, etc)
-    * Virtual USB device mount management
-    * Retrieve support data
-* OS Deployment including:
-    * Stateless images and stateful OS deployment
-    * Sample profiles for ESXi 6.7/7.0, RedHat/CentOS/Alma/Rocky 7.x/8.x/9.x, SuSE 15.x, RHV-H 4.3/4.4 and Ubuntu 20.04/22.04/24.04
-    * Deployment over PXE, HTTP(S)boot, or removable media (real or virtual)
-    * Does not require a DHCP server, nor does it conflict with an external DHCP server for all deployment methods
-    * Support customization during phases of deployment (e.g. post, firstboot, onboot) by local commands or automatically launched remote ansible playbooks.
-* Centralized access to network topology information
-    * Access mac address table and lldp information across all switches in one interface
-* Rich device on-boarding capabilities
-    * Detect generic PXE systems and Lenovo hardware management devices at a glance
-    * Rapidly onboard devices manually, based on data such as serial number or mac address, or based on where things are physically plugged in to chassis or switches.
-* Scalability and Availability
-    * Powerful noderange syntax to describe target systems simply but with great flexibility
-    * An attribute database with group inheritance and formulaic attribute derivation for structured data-centers
-    * Collective mode enables scaling a single confluent interface across multiple servers or virtual machines for HA and/or to manage thousands of systems
-    * Tools to quickly analyze data and highlight inconsistencies or to do quick statistical analysis
-* Security
-    * Designed with secure default behaviors with opt-in to reduced security
-    * Use of fully validated TLS to protect collective, deployment and hardware management
-    * Take advantage of TPM2 to protect boot volumes for supported profiles
-    * Use TPM2 to persist node trust across reboots in stateless environments
-    * Node authentication options to balance convenience versus hardening to protect potentially sensitive data such as encrypted root password
-    * SSH PKI strategy to securely enable convenient SSH without users having to self-curate SSH keys or having to update known_hosts
-    * SecureBoot is supported for media and HTTP boot methods
-* Flexible usage scenarios
-    * Collection of straightforward Linux commands
-    * Command line API browser that is like browsing a file-system
-    * Python client library
-    * REST API over HTTP
+[Get started :material-rocket-launch:](getting_started/confluentquickstart_el8.md){ .md-button .md-button--primary }
+[Download :material-download:](downloads.md){ .md-button }
 
-## Installation
+## Where to begin
 
-Generally speaking, there are two suggested approaches:
+<div class="grid cards" markdown>
 
-* Using confluent - It is strongly recommended for most of those without existing xCAT installations to use confluent directly.
-* Using xCAT and confluent together (not recommended) - When you are used to xCAT or another currently xCAT exclusive feature and want to use it in conjunction with confluent.  For this situation, start with the xCAT documentation under Advanced topics.
+-   :material-rocket-launch:{ .lg .middle } **Get started**
 
-!!! note
-    For specific topics, it may be easier to use the Search function of this site.
+    ---
+
+    Install confluent and take a single example flow from a bare management
+    server to a deployed cluster.
+
+    [:octicons-arrow-right-24: Quickstart (Enterprise Linux)](getting_started/confluentquickstart_el8.md)
+
+-   :material-server:{ .lg .middle } **Install**
+
+    ---
+
+    Set up the confluent management server on your distribution of choice and
+    open the required firewall ports.
+
+    [:octicons-arrow-right-24: Red Hat / Alma / Rocky](getting_started/installconfluent_rhel.md)
+
+    [:octicons-arrow-right-24: SUSE](getting_started/installconfluent_suse.md)
+
+    [:octicons-arrow-right-24: Ubuntu](getting_started/installconfluent_ubuntu.md)
+
+-   :material-harddisk:{ .lg .middle } **Deploy operating systems**
+
+    ---
+
+    Provision stateful and stateless images over PXE, HTTP(S) boot, or virtual
+    media, with customization at every phase.
+
+    [:octicons-arrow-right-24: OS deployment](user_reference/osdeploy.md)
+
+    [:octicons-arrow-right-24: Diskless / stateless](miscellaneous/confluentdiskless.md)
+
+-   :material-tune:{ .lg .middle } **Reference**
+
+    ---
+
+    The building blocks you use every day: node attributes, the noderange
+    language, and attribute expressions.
+
+    [:octicons-arrow-right-24: Noderange syntax](user_reference/noderange.md)
+
+    [:octicons-arrow-right-24: Attribute expressions](user_reference/attributeexpressions.md)
+
+-   :material-radar:{ .lg .middle } **Discover & onboard**
+
+    ---
+
+    Detect generic PXE systems and Lenovo hardware managers, then onboard them
+    by serial number, MAC, or physical location.
+
+    [:octicons-arrow-right-24: Discovery](user_reference/confluentdiscovery.md)
+
+-   :material-code-braces:{ .lg .middle } **Automate (API)**
+
+    ---
+
+    Drive confluent from the REST API, the Python client library, or the
+    filesystem-like `confetty` browser.
+
+    [:octicons-arrow-right-24: API documentation](developer/api.md)
+
+</div>
+
+## What confluent does
+
+<div class="grid cards" markdown>
+
+-   :material-console-line:{ .lg .middle } __Console management__
+
+    Arbitrate multi-user access with full, fine-grained timestamped logging and
+    VT-aware buffering, so a console reconnect reconstitutes cleanly.
+
+-   :material-power:{ .lg .middle } __Hardware control__
+
+    Power, next-boot device, BIOS/UEFI/BMC settings, storage controllers
+    (RAID), health checks, telemetry, virtual media, and support data over
+    IPMI, Redfish, and vendor plugins.
+
+-   :material-lan:{ .lg .middle } __Network topology__
+
+    Centralized access to MAC address tables and LLDP information across every
+    switch through one interface.
+
+-   :material-arrow-expand-all:{ .lg .middle } __Scale & availability__
+
+    Group inheritance and formulaic attribute derivation, plus collective mode
+    to span one confluent interface across servers for HA and large fleets.
+
+</div>
+
+## Security by default
+
+Confluent is designed with secure default behaviors and explicit opt-in to
+reduced security:
+
+- Fully validated TLS protects collective, deployment, and hardware management
+  traffic.
+- TPM2 can protect boot volumes and persist node trust across reboots in
+  stateless environments.
+- Node authentication options balance convenience against hardening for
+  sensitive data such as the encrypted root password.
+- An SSH PKI strategy enables convenient SSH without users curating their own
+  keys or updating `known_hosts`.
+- Secure Boot is supported for media and HTTP boot methods.
+
+See [TLS configuration](miscellaneous/tlsdesign.md),
+[SSH design](miscellaneous/sshdesign.md), and
+[OS deployment security](miscellaneous/osdeploysecurity.md) for details.
+
+## Ways to drive confluent
+
+- A collection of straightforward Linux commands (`nodepower`, `nodeconsole`,
+  `nodedeploy`, ...).
+- A command-line API browser, `confetty`, that works like browsing a filesystem.
+- A Python client library.
+- A REST API over HTTP.
+
+## Installation paths
+
+There are two suggested approaches:
+
+- **Confluent directly** *(recommended)* — best for most users, especially
+  those without an existing xCAT installation.
+- **xCAT and confluent together** — when you rely on an xCAT-exclusive feature
+  and want to use it alongside confluent. Start with the xCAT material under
+  [Advanced topics](advanced_topics/xcatconfluentsetup.md).
+
+!!! tip
+    Looking for something specific? Use the search box at the top of the page.

--- a/docs/miscellaneous/.nav.yml
+++ b/docs/miscellaneous/.nav.yml
@@ -1,0 +1,46 @@
+nav:
+  # Overview
+  - confluentvxcat.md
+  - projects.md
+  # Management and setup
+  - manageconfluent.md
+  - confluentadoptnode.md
+  - containerized-confluent.md
+  - confluentbackup.md
+  # Networking
+  - confignet.md
+  - confluentdhcp.md
+  - routeddeployment.md
+  - confluentpxedisco.md
+  # Security
+  - tlsdesign.md
+  - sshdesign.md
+  - osdeploysecurity.md
+  - makelimitedtls.md
+  # Diskless and custom images
+  - confluentdiskless.md
+  - confluentdiskless_arch.md
+  - customosimage.md
+  - raid-vroc-template.md
+  - samplepostscripts.md
+  # Collective
+  - collective_arch.md
+  # Platform-specific deployment
+  - proxmoxguide.md
+  - xccdeployment.md
+  - sd650sharednote.md
+  - sles12deploy.md
+  # Drivers and adapters
+  - doca2-10-intstall.md
+  - doca3-0-install.md
+  - bf3-troubleshooting.md
+  - nvidiagpudriverinstall.md
+  - broadcom-nic-driver-install.md
+  - rhinstallib.md
+  - rhinstallopa.md
+  - hpcxtroubleshooting.md
+  # Switches
+  - confluentcumulus.md
+  - nokia-confignotes.md
+  # Other
+  - energyhistogram.md

--- a/docs/miscellaneous/bf3-troubleshooting.md
+++ b/docs/miscellaneous/bf3-troubleshooting.md
@@ -1,9 +1,6 @@
 ---
-layout: page
 title: Troubleshooting issues with upgrading BlueField-3 BFB using DOCA (host) 3.0
-permalink: /documentation/bf3-troubleshooting.html
 ---
-
 
 # RHEL/Rocky Linux 9.5
  The following items apply for RHEL/Rocky Linux 9.5.

--- a/docs/miscellaneous/broadcom-nic-driver-install.md
+++ b/docs/miscellaneous/broadcom-nic-driver-install.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Broadcom NIC driver install on Ubuntu 24.04.2
-permalink: /documentation/broadcom-nic-driver-install.html
 ---
 
 # Broadcom NIC Driver Installation on Ubuntu 24.04.2

--- a/docs/miscellaneous/collective_arch.md
+++ b/docs/miscellaneous/collective_arch.md
@@ -1,8 +1,5 @@
 ---
-layout: page
 title: Confluent collective architecture
-permalink: /documentation/collective_arch.html
-toc: true
 ---
 
 This document will describe the design of the confluent collective implementation.

--- a/docs/miscellaneous/confignet.md
+++ b/docs/miscellaneous/confignet.md
@@ -1,8 +1,5 @@
 ---
-layout: page
 title: Confluent multi interface configuration
-permalink: /documentation/confignet.html
-toc: true
 ---
 
 Confluent profiles initialized as of 3.3 or later contain the `confignet` network configuration facility. It is invoked

--- a/docs/miscellaneous/confluentadoptnode.md
+++ b/docs/miscellaneous/confluentadoptnode.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Adding an installed node to confluent SSH setup
-permalink: /documentation/confluentadoptnode.html
 ---
 
 This procedure will provide confluent SSH configuration to a node that was not installed by confluent.

--- a/docs/miscellaneous/confluentbackup.md
+++ b/docs/miscellaneous/confluentbackup.md
@@ -1,8 +1,5 @@
 ---
-layout: page
 title: Confluent Database backup and restore
-permalink: /documentation/backup.html
-toc: true
 ---
 
 Confluent maintains its database in /etc/confluent/cfg

--- a/docs/miscellaneous/confluentcumulus.md
+++ b/docs/miscellaneous/confluentcumulus.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Using a Cumulus switch with confluent
-permalink: /documentation/confluentcumulus.html
 ---
 
 In order to use a Cumulus switch with confluent, it requires
@@ -12,7 +10,7 @@ from /opt/confluent/share/affluent/ onto the switch:
     # ssh -t cumulus@r4c1 sudo apt install ~cumulus/affluent_*.deb
 
 
-Note that if the installation occured after confluent tried to interrogate the
+Note that if the installation occurred after confluent tried to interrogate the
 switch, you may need to restart confluent:
 
     # systemctl restart confluent

--- a/docs/miscellaneous/confluentdhcp.md
+++ b/docs/miscellaneous/confluentdhcp.md
@@ -1,8 +1,5 @@
 ---
-layout: page
 title: Confluent and DHCP interaction
-permalink: /documentation/confluentdhcp.html
-toc: true
 ---
 
 For confluent OS deployment, a specific design goal is improved interoperability with DHCP infrastructure. The result is that a DHCP server

--- a/docs/miscellaneous/confluentdiskless.md
+++ b/docs/miscellaneous/confluentdiskless.md
@@ -1,8 +1,5 @@
 ---
-layout: page
 title: Using confluent diskless support
-permalink: /documentation/confluentdiskless.html
-toc: true
 ---
 
 Confluent offers the ability to create diskless images to boot operating systems. This facility is managed through the `imgutil` command.

--- a/docs/miscellaneous/confluentdiskless_arch.md
+++ b/docs/miscellaneous/confluentdiskless_arch.md
@@ -1,8 +1,5 @@
 ---
-layout: page
 title: Confluent diskless architecture
-permalink: /documentation/confluentdiskless_arch.html
-toc: true
 ---
 
 The confluent diskless implementation has a number of design points of interest compared to other diskless implementations or scripted install.

--- a/docs/miscellaneous/confluentpxedisco.md
+++ b/docs/miscellaneous/confluentpxedisco.md
@@ -1,8 +1,5 @@
 ---
-layout: page
 title: Using PXE driven discovery
-permalink: /documentation/confluentpxedisco.html
-toc: true
 ---
 
 While the best experience is through discovering the xClarity Controller first and having full management

--- a/docs/miscellaneous/confluentvxcat.md
+++ b/docs/miscellaneous/confluentvxcat.md
@@ -1,8 +1,5 @@
 ---
-layout: page
 title: xCAT and confluent comparison
-permalink: /documentation/confluentvxcat.html
-toc: true
 ---
 
 As of confluent 3.0, the scope of Confluent has increased to cover much of xCAT functionality. There will

--- a/docs/miscellaneous/containerized-confluent.md
+++ b/docs/miscellaneous/containerized-confluent.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Containerized confluent run 
-permalink: /documentation/containerized-confluent.html
 ---
 
 Synopsys

--- a/docs/miscellaneous/customosimage.md
+++ b/docs/miscellaneous/customosimage.md
@@ -1,7 +1,5 @@
 ---
 title: Creating a custom confluent OS image
-layout: page
-permalink: /documentation/customosimage.html
 ---
 
 Sometimes the options available for `osdeploy import` are too limited and an additional boot payload is

--- a/docs/miscellaneous/doca2-10-intstall.md
+++ b/docs/miscellaneous/doca2-10-intstall.md
@@ -1,9 +1,6 @@
 ---
-layout: page
 title: DOCA 2.10 Installation on RHEL 9.5
-permalink: /documentation/doca2-10-install.html
 ---
-
 
 The following procedure is for installing the NVIDIA DOCA stack (doca-ofed profile) on RHEL 9.5. 
 

--- a/docs/miscellaneous/doca3-0-install.md
+++ b/docs/miscellaneous/doca3-0-install.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: DOCA 3.0 Installation/Upgrade on RHEL 9.5 and Ubuntu 24.04.2
-permalink: /documentation/doca3-0-install.html
 ---
 
 # DOCA 3.0 Installation/Upgrade on RHEL 9.5

--- a/docs/miscellaneous/energyhistogram.md
+++ b/docs/miscellaneous/energyhistogram.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Energy histogram
-permalink: /documentation/energyhistogram.html
 ---
 
 Lenovo servers capture power level over time and provide

--- a/docs/miscellaneous/hpcxtroubleshooting.md
+++ b/docs/miscellaneous/hpcxtroubleshooting.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Troubleshooting issues with hpcx
-permalink: /documentation/hpcxtroubleshooting.html
 ---
 
 # libnuma Error

--- a/docs/miscellaneous/makelimitedtls.md
+++ b/docs/miscellaneous/makelimitedtls.md
@@ -1,3 +1,7 @@
+---
+title: Creating a scope-limited TLS certificate authority
+---
+
 This will create a certificate authority that is identical, but constrained.
 
 It will also create a certificate with SAN values limited to the authorized scope, as TLS

--- a/docs/miscellaneous/manageconfluent.md
+++ b/docs/miscellaneous/manageconfluent.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Managing hardware using confluent
-permalink: /documentation/manageconfluent.html
 ---
 
 As mentioned in the [configuring confluent](../getting_started/configureconfluent.md) section,

--- a/docs/miscellaneous/nokia-confignotes.md
+++ b/docs/miscellaneous/nokia-confignotes.md
@@ -1,5 +1,4 @@
 ---
-
 title: Confluent configuration and troubleshooting notes for Nokia Ethernet switches
 ---
 

--- a/docs/miscellaneous/nvidiagpudriverinstall.md
+++ b/docs/miscellaneous/nvidiagpudriverinstall.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: NVIDIA GPU Driver Install on RHEL 9.5 and Ubuntu 24.04.2
-permalink: /documentation/nvidiagpudriverinstall.html
 ---
 
 # NVIDIA GPU Driver Install on RHEL 9.5

--- a/docs/miscellaneous/osdeploysecurity.md
+++ b/docs/miscellaneous/osdeploysecurity.md
@@ -1,8 +1,5 @@
 ---
-layout: page
 title: Handling of security information in OS deployment
-permalink: /documentation/osdeploysecurity.html
-toc: true
 ---
 
 # SSH host and user authentication

--- a/docs/miscellaneous/proxmoxguide.md
+++ b/docs/miscellaneous/proxmoxguide.md
@@ -1,8 +1,7 @@
 ---
-layout: page
 title: Proxmox Guide with Confluent
-toc: true
 ---
+
 # Proxmox Guide with Confluent
 
 ## Installing proxmox
@@ -55,15 +54,15 @@ In order to use VMs as nodes, you will probably want to change the networking to
 
 First, you will want to clear the configuration from the current nic that you want to turn into a bridge.  Don't worry, changes will not apply even when you click 'OK'.  This is needed to make the network addresses available to the bridge.
 
-![clearnic](../../assets/Proxmox/CreateNetworking-1ClearNicConfig.png)
+![clearnic](../assets/Proxmox/CreateNetworking-1ClearNicConfig.png)
 
 You will want to select to create a new bridge
 
-![selectbridge](../../assets/Proxmox/CreateNetworking-2SelectBridge.png)
+![selectbridge](../assets/Proxmox/CreateNetworking-2SelectBridge.png)
 
 Finally, apply the network configuration and make sure to include the port name in the configuration.
 
-![newbridge](../../assets/Proxmox/CreateNetworking-3SetupNewBridge.png)
+![newbridge](../assets/Proxmox/CreateNetworking-3SetupNewBridge.png)
 
 When finished, click `Apply Configuration` to continue.
 
@@ -74,35 +73,35 @@ If you want to use the WebUI, here's an example of creating a VM:
 
 Select `Create VM` from the right click menu on the host.  For name, have the VM name match the node name you will want in confluent.
 
-![createvmdropdown](../../assets/Proxmox/CreateVM-1.png)
+![createvmdropdown](../assets/Proxmox/CreateVM-1.png)
 
 Do not use any media; we will be using confluent for the OS deployment instead.
 
-![skipmedia](../../assets/Proxmox/CreateVM-2.png)
+![skipmedia](../assets/Proxmox/CreateVM-2.png)
 
 For system, you will likely want to add a TPM and select storage for the TPM. This allows better diskless boot behaviors in the VM.
 
-![addtpm](../../assets/Proxmox/CreateVM-3AddTPM.png)
+![addtpm](../assets/Proxmox/CreateVM-3AddTPM.png)
 
 You can select disk size as appropriate.  Here we selected write-back cache for better performance.
 
-![adddisk](../../assets/Proxmox/CreateVM-4AddDisk.png)
+![adddisk](../assets/Proxmox/CreateVM-4AddDisk.png)
 
 For CPU, you will likely want to change to `host`, as the default is incompatible with some newer distributions.
 
-![setcpu](../../assets/Proxmox/CreateVM-5HostCPU.png)
+![setcpu](../assets/Proxmox/CreateVM-5HostCPU.png)
 
 You will likely want more memory than the default. OS installers run from ramfs and some can require a few gigabytes.
 
-![setmem](../../assets/Proxmox/CreateVM-6SetMemory.png)
+![setmem](../assets/Proxmox/CreateVM-6SetMemory.png)
 
 Here we select the bridge we created before.
 
-![setnet](../../assets/Proxmox/CreateVM-7SetNetworking.png)
+![setnet](../assets/Proxmox/CreateVM-7SetNetworking.png)
 
 Review settings and click 'Finish' to create the VM
 
-![confirmvm](../../assets/Proxmox/CreateVM-8Confirm.png)
+![confirmvm](../assets/Proxmox/CreateVM-8Confirm.png)
 
 ### Using CLI to create a virtual machine
 
@@ -171,7 +170,7 @@ The node is now ready for use as a normal node, for example, to boot a diskless 
 
 If you add a serial port to the VM, then you can use console.method=proxmox to have a SOL console in nodeconsole.  Other than that, the graphics console in proxmox VMs is supported in the confluent webui as well as nodeconsole:
 
-![nodeconsole](../../assets/Proxmox/nodeconsole.png)
+![nodeconsole](../assets/Proxmox/nodeconsole.png)
 
 Nodeinventory also works:
 

--- a/docs/miscellaneous/raid-vroc-template.md
+++ b/docs/miscellaneous/raid-vroc-template.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Template for RAID/VROC boot device 
-permalink: /documentation/raid-vroc-template.html
 ---
 
 Synopsis

--- a/docs/miscellaneous/rhinstallib.md
+++ b/docs/miscellaneous/rhinstallib.md
@@ -1,8 +1,5 @@
 ---
-layout: page
 title: Installing EL7 over InfiniBand
-permalink: /documentation/el7ibinstall.html
-toc: true
 ---
 
 This covers the process of EL7 deployment on a cluster using only InfiniBand.

--- a/docs/miscellaneous/rhinstallopa.md
+++ b/docs/miscellaneous/rhinstallopa.md
@@ -1,8 +1,5 @@
 ---
-layout: page
 title: Installing EL7 over OmniPath
-permalink: /documentation/el7opainstall.html
-toc: true
 ---
 
 It is possible with the Lenovo xCAT and confluent software to install

--- a/docs/miscellaneous/routeddeployment.md
+++ b/docs/miscellaneous/routeddeployment.md
@@ -1,9 +1,7 @@
 ---
-layout: page
 title: Deployment through a routed network
-permalink: /documentation/routed-deployment.html
-toc: true
 ---
+
 While it is most straightforward to do OS deployment when on the same network, sometimes there is a need to deploy through
 a routed network.  Note that regardless of the strategy, the routed network will incur more manual configuration and have more
 chances for a failure to occur, so it is strongly advised, if at all possible, to have confluent on the local network, or use

--- a/docs/miscellaneous/samplepostscripts.md
+++ b/docs/miscellaneous/samplepostscripts.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Osdeployment sample postscripts and their usage
-permalink: /documentation/samplepostscripts.html
 ---
 
 Listed here are some sample post scripts that you might choose to use when deploying 

--- a/docs/miscellaneous/sd650sharednote.md
+++ b/docs/miscellaneous/sd650sharednote.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Configured for shared port in SD650 in xCAT
-permalink: /documentation/sd650sharednote.html
 ---
 
 The SD650 water cooled system requires the following value for the `ipmi.bmcport` field of the node

--- a/docs/miscellaneous/sles12deploy.md
+++ b/docs/miscellaneous/sles12deploy.md
@@ -1,9 +1,6 @@
 ---
-layout: page
 title: OS Deployment Notes for SLES 12.3
-permalink: /documentation/sles12deploy.html
 ---
-
 
 After performing copycds on disk 2 of the SLES 12 media, SUSE may experience problems interacting with the install source, such as:                                                             
 

--- a/docs/miscellaneous/sshdesign.md
+++ b/docs/miscellaneous/sshdesign.md
@@ -1,9 +1,7 @@
 ---
-layout: page
 title: Confluent SSH Configuration
-permalink: /documentation/sshdesign.html
-toc: true
 ---
+
 # SSH authentication architecture as configured by confluent
 
 In confluent, some more advanced SSH features are leveraged to tighten secure use of passwordless SSH and

--- a/docs/miscellaneous/tlsdesign.md
+++ b/docs/miscellaneous/tlsdesign.md
@@ -1,9 +1,7 @@
 ---
-layout: page
 title: Confluent TLS Configuration
-permalink: /documentation/tlsdesign.html
-toc: true
 ---
+
 # Challenges of using TLS in a private network
 
 Using TLS in a private network configuration can be daunting. The usual approach requires that DNS be in order and resolving the way that is intended and imposes a requirement that the user explicitly tell the software correctly the name that will be used.  Further, when faced with multihomed systems, it adds more complexity, as the certificate must cover all possible names and the software must use the correct name at the correct time, depending on context.
@@ -21,7 +19,7 @@ Note that every possible ip address is added, and added both properly as IP addr
 
 # The confluent TLS authority
 
-To allow easily updating the certificate to accomodate IP address changes, confluent tends to make it's own certificate authority:
+To allow easily updating the certificate to accommodate IP address changes, confluent tends to make it's own certificate authority:
 ```
 /etc/confluent/tls/cakey.pem
 /etc/confluent/tls/cacert.pem

--- a/docs/miscellaneous/xccdeployment.md
+++ b/docs/miscellaneous/xccdeployment.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Deploying servers using the xClarity Controller
-permalink: /documentation/xccdeployment.html
 ---
 
 This procedure will leverage the Virtual USB function on appropriately licensed

--- a/docs/release_notes/posts/2024-02-13-24arelease.md
+++ b/docs/release_notes/posts/2024-02-13-24arelease.md
@@ -42,7 +42,7 @@ Some mistakes could be made in abbreviating noderange featuring complex names. T
 ## Filter multipath nvme while determining install disk.
 
 nvme devices may materialize path information, which confused the search for install disks. This is
-now accomodated.
+now accommodated.
 
 ## Improve noderange error messages on certain cases
 

--- a/docs/release_notes/posts/2025-01-06-24brelease.md
+++ b/docs/release_notes/posts/2025-01-06-24brelease.md
@@ -77,7 +77,7 @@ The network configuration step is repeated until success, rather than only makin
 ### The web GUI now honors system light/dark theme preference
 
 When you select a light or dark theme for your desktop, the new confluent GUI will attempt
-to accomodate that preference.
+to accommodate that preference.
 
 ### Import OS images through a browser
 

--- a/docs/release_notes/posts/2025-05-14-3131release.md
+++ b/docs/release_notes/posts/2025-05-14-3131release.md
@@ -1,6 +1,7 @@
 ---
 date: 2025-05-14
 ---
+
 # 3.13.1 Confluent release
 
 3.13.1 has been released with the following changes:

--- a/docs/release_notes/posts/2025-08-27-3141release.md
+++ b/docs/release_notes/posts/2025-08-27-3141release.md
@@ -1,6 +1,7 @@
 ---
 date: 2025-08-27
 ---
+
 # 3.14.1 Confluent release
 
 3.14.1 has been released with the following changes:

--- a/docs/release_notes/posts/2026-04-10-3151release.md
+++ b/docs/release_notes/posts/2026-04-10-3151release.md
@@ -13,7 +13,7 @@ If someone modifies service.cfg to open confluent directly to external access, t
 
 ## Support for Nokia SRLinux
 
-Switches running SRLinux have enhanced capabilities.  `hardwaremanagement.method` set to `srlinux` will enable a number of commands. See [Confluent configuration notes for Nokia Ethernet switches](../miscellaneous/nokia-confignotes.md) for more detail.
+Switches running SRLinux have enhanced capabilities.  `hardwaremanagement.method` set to `srlinux` will enable a number of commands. See [Confluent configuration notes for Nokia Ethernet switches](../../miscellaneous/nokia-confignotes.md) for more detail.
 
 
 ## `nodeapply` can now request execution of ansible plays

--- a/docs/troubleshooting/.nav.yml
+++ b/docs/troubleshooting/.nav.yml
@@ -1,0 +1,7 @@
+nav:
+  - confluentosdeployts.md
+  - confluentnodefirmwareupdatetroubleshooting.md
+  - attributeexpressionstroubleshooting.md
+  - nodeshelltroubleshooting.md
+  - confluentupdatesles.md
+  - xcatosdeploymentts.md

--- a/docs/troubleshooting/attributeexpressionstroubleshooting.md
+++ b/docs/troubleshooting/attributeexpressionstroubleshooting.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Troubleshooting issues with nodeattribute expressions. 
-permalink: /documentation/nodeattribexpressionstroubleshooting.html
 ---
 
 An expression will contain some directives wrapped in {} characters.

--- a/docs/troubleshooting/confluentnodefirmwareupdatetroubleshooting.md
+++ b/docs/troubleshooting/confluentnodefirmwareupdatetroubleshooting.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Troubleshooting issues with nodefirmware and firmware updates
-permalink: /documentation/confluentnodefirmwareupdatetroubleshooting.html
 ---
 
 ## Known issues:
@@ -14,30 +12,34 @@ permalink: /documentation/confluentnodefirmwareupdatetroubleshooting.html
     # ls -1 *
     ```
 
-    index.json
-    lnvgy_fw_xcc_qgx306n-1.00_anyos_comp.chg\
-    lnvgy_fw_xcc_qgx306n-1.00_anyos_comp.html\
-    lnvgy_fw_xcc_qgx306n-1.00_anyos_comp_index.json\
-    lnvgy_fw_xcc_qgx306n-1.00_anyos_comp_inventory.json\
-    lnvgy_fw_xcc_qgx306n-1.00_anyos_comp_signature.json\
-    lnvgy_fw_xcc_qgx306n-1.00_anyos_comp.txt\
+```bash
+index.json
+lnvgy_fw_xcc_qgx306n-1.00_anyos_comp.chg\
+lnvgy_fw_xcc_qgx306n-1.00_anyos_comp.html\
+lnvgy_fw_xcc_qgx306n-1.00_anyos_comp_index.json\
+lnvgy_fw_xcc_qgx306n-1.00_anyos_comp_inventory.json\
+lnvgy_fw_xcc_qgx306n-1.00_anyos_comp_signature.json\
+lnvgy_fw_xcc_qgx306n-1.00_anyos_comp.txt\
 
-    payloads:\
-    lnvgy_fw_xcc_qgx306n-1.00_anyos_comp.uxz
+payloads:\
+lnvgy_fw_xcc_qgx306n-1.00_anyos_comp.uxz
 
-    The *.uxz file under the payloads directory may then be used to update the XCC backup firmware in the usual fashion:
-    ```
-    # nodefirmware <nodename> update payloads/lnvgy_fw_xcc_qgx306n-1.00_anyos_comp.uxz --backup
-    ```
+The *.uxz file under the payloads directory may then be used to update the XCC backup firmware in the usual fashion:
+```
+# nodefirmware <nodename> update payloads/lnvgy_fw_xcc_qgx306n-1.00_anyos_comp.uxz --backup
+```
+```
 
 2. In some cases updating the XCC primary firmware with nodefirmware on Lenovo servers may fail with an error, such as below, when using the default *.zip file such as lnvgy_fw_xcc_qgx306n-1.00_anyos_comp.zip:
 
     Nodes had errors updating (\<nodename>)! \<nodename>: ('[{"@odata.type": "#Message.v1_1_2.Message", "MessageId": "Update.1.0.VerificationFailed", "MessageSeverity": "Critical", "Message": "Verification of image \'upload_file\' at \'Unknown\' failed.", "Resolution": "None.", "MessageArgs": ["upload_file", "Unknown"]}]',)
 
-    As in item 1. above, the problem can be worked around by extracting the *.uxz payload file from the *.zip package and using it directly:
-    ```
-    #nodefirmware <nodename> update payloads/lnvgy_fw_xcc_qgx306n-1.00_anyos_comp.uxz
-    ```
+```bash
+As in item 1. above, the problem can be worked around by extracting the *.uxz payload file from the *.zip package and using it directly:
+```
+#nodefirmware <nodename> update payloads/lnvgy_fw_xcc_qgx306n-1.00_anyos_comp.uxz
+```
+```
 
 3. After updating XCC or UEFI firmware, the “Pending” status may not show if the system is managed via Redfish. The update is in fact pending, but the status does not show. To get the status to show, change the management method to IPMI:
     ```

--- a/docs/troubleshooting/confluentosdeployts.md
+++ b/docs/troubleshooting/confluentosdeployts.md
@@ -1,9 +1,7 @@
 ---
-layout: page
 title: Troubleshooting issues with confluent OS deployment
-permalink: /documentation/confluentosdeploymenttroubleshooting.html
-toc: true
 ---
+
 # IPv6 configuration
 
 Deployment interfaces must have IPv6 enabled, with at least an automatic fe80:: address.  Generally this is default network interface configuration.  IPv6 need only be enabled, it need not be given any address manually, by DHCP, or by route advertisements, the automatic fe80:: addresses suffice.
@@ -12,17 +10,21 @@ Deployment interfaces must have IPv6 enabled, with at least an automatic fe80:: 
 
 An attempt to import media after an error or abort may result in:
 
-    {u'errorcode': 500, u'error': u'Unexpected error - Media import already in progress for this media'}
+```bash
+{u'errorcode': 500, u'error': u'Unexpected error - Media import already in progress for this media'}
+```
 
 In order to proceed, the older import activity must be stopped. This can be done by listing current import activity,
 and removing it using confetty:
 
-    # osdeploy import CentOS-Stream-8-x86_64-20210118-dvd1.iso 
-    {'errorcode': 500, 'error': 'Unexpected error - Media import already in progress for this media'}
-    # confetty show /deployment/importing
-    centos_stream-8.4-x86_64
-    # confetty rm /deployment/importing/centos_stream-8.4-x86_64
-    Deleted: deployment/importing/centos_stream-8.4-x86_64
+```bash
+# osdeploy import CentOS-Stream-8-x86_64-20210118-dvd1.iso 
+{'errorcode': 500, 'error': 'Unexpected error - Media import already in progress for this media'}
+# confetty show /deployment/importing
+centos_stream-8.4-x86_64
+# confetty rm /deployment/importing/centos_stream-8.4-x86_64
+Deleted: deployment/importing/centos_stream-8.4-x86_64
+```
 
 # Can't ssh from the management node to a managed node after deployment, or from a managed node to another managed node after deployment
 

--- a/docs/troubleshooting/confluentupdatesles.md
+++ b/docs/troubleshooting/confluentupdatesles.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Troubleshooting issue with updating confluent on SLES 15
-permalink: /documentation/confluentupdatesles.html
 ---
 
 ## Known Issue: 

--- a/docs/troubleshooting/nodeshelltroubleshooting.md
+++ b/docs/troubleshooting/nodeshelltroubleshooting.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Confluent nodeshell and apt-get command
-permalink: /documentation/nodeshelltroubleshooting.html
 ---
 
 #### Running the `apt-get install` command can be interactive and so not suited for running through Confluent `nodeshell` command. 

--- a/docs/troubleshooting/xcatosdeploymentts.md
+++ b/docs/troubleshooting/xcatosdeploymentts.md
@@ -1,8 +1,7 @@
 ---
-layout: page
 title: Troubleshooting issues with xCAT OS deployment and diskless image creation/boot
-permalink: /documentation/xcatosdeploymenttroubleshooting.html
 ---
+
 # xCAT OS deployment or diskless image boot fails with message regarding ib=dhcp
 
 The ib=dhcp kernel command line argument is added by default to the bootloader configuration files on the xCAT management server at /tftpboot/xcat/xnba/nodes/<node>* .  When a kernel command line paramer is set to set the ip= argument more explicitly, for example using bootparams.addkcmdline for boot over IB, then the ip=dhcp argument in the kernel command line arguments in the bootloader configuration file is superfluous and can cause problems.  To work-around this error the "ip=dhcp" entry in the bootloader configuration file should be removed.  Note, this will have to be re-done, after performing nodeset.
@@ -40,12 +39,14 @@ Presuming that the image has been created in the `/imagebuild` directory on the 
                                                                 
         for i in dev sys proc; do umount /imagebuild/rootimg/$i ; done
 
-    `/dev` will occasionally report that it is busy. If this happens, do
-    
-        umount -l /imagebuild/rootimg/dev
-                                                                
-    Confirm success by running the `mount` command and make sure nothing is mounted under `/imagebuild/rootimg`               
-                                                                
+```bash
+`/dev` will occasionally report that it is busy. If this happens, do
+
+    umount -l /imagebuild/rootimg/dev
+                                                            
+Confirm success by running the `mount` command and make sure nothing is mounted under `/imagebuild/rootimg`               
+```
+
 6.  Proceed with the process step "Copy the local genimage output to the correct location on the Management Node:"    
 
 <br>

--- a/docs/user_reference/.nav.yml
+++ b/docs/user_reference/.nav.yml
@@ -1,0 +1,16 @@
+nav:
+  - osdeploy.md
+  - noderange.md
+  - attributeexpressions.md
+  - confluentdiscovery.md
+  - confluentrackview.md
+  - switchportattribs.md
+  - thermalpowerconfluent.md
+  - confluentconfignotes.md
+  - chainedsmmdiscovery.md
+  - diskless_memory_usage.md
+  - centosdeploy.md
+  - el7deploy.md
+  - suse15deploy.md
+  - ubuntudeploy.md
+  - updatesw_rhel.md

--- a/docs/user_reference/attributeexpressions.md
+++ b/docs/user_reference/attributeexpressions.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Attribute Expressions
-permalink: /documentation/attributeexpressions.html
 ---
 
 In confluent, any attribute may either be a straightforward value, or an expression
@@ -20,8 +18,10 @@ useful.  As an example, if we have a scheme where nodes are numbered n1-n512, an
 1-42 in rack1, 43-84 in rack2, and so forth, it is convenient to perform arithmetic on the extracted
 number.  Here is an example of codifying the above scheme, and setting the u to the remainder:
 
-	location.rack=rack{(n1-1)/42+1}
-	location.u={(n1-1)%42+1}
+```bash
+location.rack=rack{(n1-1)/42+1}
+location.u={(n1-1)%42+1}
+```
 
 Note how text may be mixed into expressions, only data within {} will receive special treatment.
 Here we also had to adjust by subtracting 1 and adding it back to make the math work as expected.
@@ -29,35 +29,47 @@ Here we also had to adjust by subtracting 1 and adding it back to make the math 
 It is sometimes the case that the number must be formatted a different way, either specifying 0 padding
 or converting to hexadecimal.  This can be done by a number of operators at the end to indicate formatting changes.
 
-	{n1:02x} - Zero pad to two decimal places, and convert to hexadecimal, as might be used for generating MAC addresses
-	{n1:x} - Hexadecimal without padding, as may be used in a generated IPv6 address
-	{n1:X} - Uppercase hexadecimal
-	{n1:02d} - Zero pad a normal numeric representation of the number.
+```bash
+{n1:02x} - Zero pad to two decimal places, and convert to hexadecimal, as might be used for generating MAC addresses
+{n1:x} - Hexadecimal without padding, as may be used in a generated IPv6 address
+{n1:X} - Uppercase hexadecimal
+{n1:02d} - Zero pad a normal numeric representation of the number.
+```
 
 Another common element to pull into an expression is the node name in whole:
 
-	hardwaremanagement.manager={nodename}-imm
+```bash
+hardwaremanagement.manager={nodename}-imm
+```
 
 Additionally other attributes may be pulled in:
 
-	net.switchport={location.u}
+```bash
+net.switchport={location.u}
+```
 
 Multiple expressions are permissible within a single attribute:
 
-	hardwaremanagement.manager={nodename}-{hardwaremanagement.method}
+```bash
+hardwaremanagement.manager={nodename}-{hardwaremanagement.method}
+```
 
 A note to developers: in general the API layer will automatically recognize a generic
 set attribute to string with expression syntax and import it as an expression.  For example,
 submitting the following JSON:
 
-	{ 'location.rack': '{n1}' }
+```bash
+{ 'location.rack': '{n1}' }
+```
 
 Will auto-detect {n1} as an expression and assign it normally.  If wanting to set that value
 verbatim, it can either be escaped by doubling the {} or by explicitly declaring it as a value:
 
-	{ 'location.rack': '{% raw %}{{n1}}{% endraw %}' }
+```bash
+{ 'location.rack': '{% raw %}{{n1}}{% endraw %}' }
 
-	{ 'location.rack': { 'value': '{n1}' } }
+{ 'location.rack': { 'value': '{n1}' } }
+```
 
 
 

--- a/docs/user_reference/centosdeploy.md
+++ b/docs/user_reference/centosdeploy.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: OS Deployment Notes for CentOS
-permalink: /documentation/centosdeploy.html
 ---
 
 When deploying CentOS, the default behavior is to have the CentOS
@@ -11,11 +9,15 @@ one of the following commands:
 
 Disable the repositories (requires yum-utils package to be installed):
 
-    yum-config-manager --disable CentOS-*
+```bash
+yum-config-manager --disable CentOS-*
+```
 
 If yum-utils is not available, the repositories may instead be removed:
 
-    rm /etc/yum.repos.d/CentOS-*repo
+```bash
+rm /etc/yum.repos.d/CentOS-*repo
+```
 
 If executing genimage multiple times, it may be required to delete the image between runs. This
 is due to certain assumptions that, among other things, could erase /etc/passwd without

--- a/docs/user_reference/chainedsmmdiscovery.md
+++ b/docs/user_reference/chainedsmmdiscovery.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Discovery with chained ThinkSystem D2 enclosures
-permalink: /documentation/chainedsmmdiscovery.html
 ---
 
 The ThinkSystem D2 enclosure (which houses SD530 servers) has a variant of System Management Module (SMM) that supports chaining

--- a/docs/user_reference/confluentconfignotes.md
+++ b/docs/user_reference/confluentconfignotes.md
@@ -1,36 +1,35 @@
 ---
-layout: page
 title: Confluent configuration and troubleshooting notes for Lenovo hardware
-permalink: /documentation/confluentconfignotes.html
-toc: true
 ---
 
 ## SN2010 rack view
 
 The SN2010* Ethernet switch is half-wide and 1U tall, but also doesn’t install into an enclosure.  Due to this, it doesn’t fit into the normal way of setting up location information for the confluent nodeattributes for it so that it would be displayed in the rack view in the confluent GUI.  In order to get it to be displayed properly in the confluent GUI rack view (when there are two installed side-by-side in the same rack unit), a dummy enclosure node has to be setup, and the two switches in that rack unit have to have their enclosure node attributes set to that enclosure.  The enclosure.bay nodeattribute should be set to 1 for the switch installed to the left (as seen from the front of the rack) and to 2 for the switch installed in the right.  The following is an example of the confluent nodeattributes to set for this:
 
-    mn10:/opt/exerciser # nodeattrib switch90
-    switch90: discovery.policy: open
-    switch90: dns.domain: cluster1.e1350
-    switch90: enclosure.bay: 1
-    switch90: enclosure.manager: switch9091
-    switch90: groups: everything
+```bash
+mn10:/opt/exerciser # nodeattrib switch90
+switch90: discovery.policy: open
+switch90: dns.domain: cluster1.e1350
+switch90: enclosure.bay: 1
+switch90: enclosure.manager: switch9091
+switch90: groups: everything
 
-    mn10:/opt/exerciser # nodeattrib switch91
-    switch91: discovery.policy: open
-    switch91: dns.domain: cluster1.e1350
-    switch91: enclosure.bay: 2
-    switch91: enclosure.manager: switch9091
-    switch91: groups: everything
+mn10:/opt/exerciser # nodeattrib switch91
+switch91: discovery.policy: open
+switch91: dns.domain: cluster1.e1350
+switch91: enclosure.bay: 2
+switch91: enclosure.manager: switch9091
+switch91: groups: everything
 
-    mn10:/opt/exerciser # nodeattrib switch9091
-    switch9091: discovery.policy: open
-    switch9091: dns.domain: cluster1.e1350
-    switch9091: groups: everything
-    switch9091: location.height: 1
-    switch9091: location.rack: CR021.2
-    switch9091: location.row: 2
-    switch9091: location.u: 41
+mn10:/opt/exerciser # nodeattrib switch9091
+switch9091: discovery.policy: open
+switch9091: dns.domain: cluster1.e1350
+switch9091: groups: everything
+switch9091: location.height: 1
+switch9091: location.rack: CR021.2
+switch9091: location.row: 2
+switch9091: location.u: 41
+```
 
 And here is the result of this in the confluent rack view:
 
@@ -47,34 +46,42 @@ to activate the change so that it will be visible when showing the configuration
 
 For SR655 nodes configured to be managed with Redfish, IPv6 and domain name resolution may not work for node attribute values. For example, it is known to not work in the case of the `hardwaremanagement.manager` attribute. In the example below:
 
-    # nodeattrib node1 hardwaremanagement.method
-    node1:  hardwaremanagement.method:  redfish
+```bash
+# nodeattrib node1 hardwaremanagement.method
+node1:  hardwaremanagement.method:  redfish
 
-    # nodeattrib node1 hardwaremanagement.manager
-    node1:  hardwaremanagement.manager: node1-mgt
+# nodeattrib node1 hardwaremanagement.manager
+node1:  hardwaremanagement.manager: node1-mgt
+```
 
 Or:
     
-    # nodeattrib node1 hardwaremanagement.manager
-    node1:  hardwaremanagement.manager: fe80::3ee1:a1ff:fec7:e627%eno1
+```bash
+# nodeattrib node1 hardwaremanagement.manager
+node1:  hardwaremanagement.manager: fe80::3ee1:a1ff:fec7:e627%eno1
+```
 
 The domain name `node1-mgt1` will trigger an error on the target TSM, causing the following error:
 
-    # nodefirmware node1
-    
-    Traceback (most recent call last):
-      File "/opt/confluent/bin/nodefirmware", line 166, in <module>
-        show_firmware(session)
-      File "/opt/confluent/bin/nodefirmware", line 152, in show_firmware
-        exitcode |= client.printerror(res['databynode'][node], node)
-      File "/opt/confluent/lib/python/confluent/client.py", line 116, in printerror
-        sys.stderr.write('{0}: {1}\n'.format(node, res['error']))
-    UnicodeEncodeError: 'ascii' codec can't encode characters in position 175-254: ordinal not in range(128)
+```bash
+# nodefirmware node1
+
+Traceback (most recent call last):
+  File "/opt/confluent/bin/nodefirmware", line 166, in <module>
+    show_firmware(session)
+  File "/opt/confluent/bin/nodefirmware", line 152, in show_firmware
+    exitcode |= client.printerror(res['databynode'][node], node)
+  File "/opt/confluent/lib/python/confluent/client.py", line 116, in printerror
+    sys.stderr.write('{0}: {1}\n'.format(node, res['error']))
+UnicodeEncodeError: 'ascii' codec can't encode characters in position 175-254: ordinal not in range(128)
+```
 
 Or IPv6 will trigger this error:
 
-     # nodefirmware node1
-     node1: Unexpected Error: /redfish/v1/Managers/Self:<pre style="font-size:12px; font-family:monospace; color:#8B0000;">[web.lua] Error in RequestHandler, thread: 0x758476e8 is dead.
+```bash
+ # nodefirmware node1
+ node1: Unexpected Error: /redfish/v1/Managers/Self:<pre style="font-size:12px; font-family:monospace; color:#8B0000;">[web.lua] Error in RequestHandler, thread: 0x758476e8 is dead.
+```
 
 There are two options to address the problem:
 

--- a/docs/user_reference/confluentdiscovery.md
+++ b/docs/user_reference/confluentdiscovery.md
@@ -1,8 +1,5 @@
 ---
-layout: page
 title: Node discovery and autoconfiguration with confluent
-permalink: /documentation/confluentdisco.html
-toc: true
 ---
 
 Note that discovery is an optional portion of confluent that may be skipped.
@@ -39,11 +36,13 @@ servers to configure or replacing a server or system board.
 
 Discovery can be followed by examining `/var/log/confluent/events`, Using `tail -f` for example:
 
-    May 25 16:28:25 {"info": "Discovered n1 (XCC)"} 
-    May 25 16:28:37 {"info": "Discovered n4 (XCC)"}
-    May 25 16:28:38 {"info": "Discovered n2 (XCC)"} 
-    May 25 16:28:40 {"info": "Discovered n3 (XCC)"}
-    
+```bash
+May 25 16:28:25 {"info": "Discovered n1 (XCC)"} 
+May 25 16:28:37 {"info": "Discovered n4 (XCC)"}
+May 25 16:28:38 {"info": "Discovered n2 (XCC)"} 
+May 25 16:28:40 {"info": "Discovered n3 (XCC)"}
+```
+
 
 ## Manual discovery
 
@@ -112,17 +111,19 @@ ok
 
 If there are switches defined, their mac address tables can be navigated through the `/networking/macs` interface.  Using the mac address example from above:
 
-    / -> show /networking/macs/by-mac/40-f2-e9-b9-10-1d
-    possiblenode=""
-    mac: 40:f2:e9:b9:10:1d
-    ports=[
-     {
-      "switch": "r8e1", 
-      "macsonport": 1, 
-      "port": "Ethernet28"
-     }
-    ]
-    / -> 
+```bash
+/ -> show /networking/macs/by-mac/40-f2-e9-b9-10-1d
+possiblenode=""
+mac: 40:f2:e9:b9:10:1d
+ports=[
+ {
+  "switch": "r8e1", 
+  "macsonport": 1, 
+  "port": "Ethernet28"
+ }
+]
+/ -> 
+```
 
 
 You may also use this to get the mac addresses from an ethernet port, if you do not know the mac address:
@@ -144,10 +145,12 @@ xClarity Controller with the address '10.2.3.(node number)', and the username an
 password of your choice.  Here we will use a group to hold the patterns and just define the nodes
 with just the single group membership:
 
-    nodegroupdefine compute bmc=10.2.3.{n1}
-    nodegroupattrib compute -p bmcuser bmcpass
-    nodegroupattrib compute net.<name>.ipv4_gateway=<IP of gateway for xClarity Controllers to use)
-    nodedefine n1-n42 groups=compute
+```bash
+nodegroupdefine compute bmc=10.2.3.{n1}
+nodegroupattrib compute -p bmcuser bmcpass
+nodegroupattrib compute net.<name>.ipv4_gateway=<IP of gateway for xClarity Controllers to use)
+nodedefine n1-n42 groups=compute
+```
 
 This will interactively prompt for username and password. This is the desired username and password not necessarily the current.
 If the devices are at factory default, then they will be changed automatically to the password and username given.
@@ -181,18 +184,24 @@ automate.  In this mode, ethernet mac addresses will be collected to a `net.<n>.
 
 The policy can be defined on a per node basis or by group.  Here we will select `permissive,pxe` across the board, and enable PXE collection to a field called `net.pxe.hwaddr`:
 
-    nodegroupattrib everything discovery.policy=permissive,pxe net.pxe.bootable=true
+```bash
+nodegroupattrib everything discovery.policy=permissive,pxe net.pxe.bootable=true
+```
 
 The policy can be changed on the fly, if for example you want `open` or `permissive`
 during initial deployment, but change to `manual` after systems are up:
 
-    nodegroupattrib everything discovery.policy=manual
+```bash
+nodegroupattrib everything discovery.policy=manual
+```
 
 If you have a system that needs to be replaced, you can use manual discovery as
 documented in the previous section or temporarily override the policy for just the
 one node:
 
-    nodeattrib n3 discovery.policy=open
+```bash
+nodeattrib n3 discovery.policy=open
+```
 
 ### Defining required attributes on the nodes, enclosure managers, and switches
 
@@ -201,27 +210,37 @@ has a management port plugged into a switch called `r8e1` on port 8.
 
 First we set the enclosure attributes on the nodes:
 
-    nodeattrib n1-n4 enclosure.manager=enc1 enclosure.bay={n1}
-    
+```bash
+nodeattrib n1-n4 enclosure.manager=enc1 enclosure.bay={n1}
+```
+
 We then make sure the enclosure manager is a node and configure the location of
 it's switch port:
 
-    nodeattrib enc1 net.switchport=8 net.switch=r8e1
-    
+```bash
+nodeattrib enc1 net.switchport=8 net.switch=r8e1
+```
+
 By default, confluent will assume it can use SNMPv1/v2c, community string `public`
 to communicate with the switch.  To use a different SNMP community string, make
 sure the ethernet switch is defined as a node and set a value for secret.snmpcommunity:
 
-    nodedefine r8e1 secret.snmpcommunity=otherpublic
+```bash
+nodedefine r8e1 secret.snmpcommunity=otherpublic
+```
 
 Or for SNMPv3, use secret.hardwaremanagementuser and hardwaremanagementpassword:
 
-    nodedefine r8e1 secret.hardwaremanagementuser=snmpv3user secret.hardwaremanagementpassword=snmpv3password
+```bash
+nodedefine r8e1 secret.hardwaremanagementuser=snmpv3user secret.hardwaremanagementpassword=snmpv3password
+```
 
 In the event of a rackmount system, such as the [Thinksystem SD650](http://www3.lenovo.com/us/en/data-center/servers/racks/Lenovo-ThinkSystem-SR650/p/77XX7SRSR65),
 simply assign net attributes directly to the node:
 
-    nodeattrib n1-n20 net.switchport={n1} net.switch=r8e1
+```bash
+nodeattrib n1-n20 net.switchport={n1} net.switch=r8e1
+```
 
 
 ### Resetting automatic discovery process for nodes
@@ -229,11 +248,15 @@ simply assign net attributes directly to the node:
 If the wiring or configuration of set of nodes was incorrect at time of discovery,
 the situation can be corrected by doing [manual discovery](#manual-discovery) or by resetting the discovery process for the nodes.  Resetting the automatic discovery process can be done by clearing the `pubkeys.tls_hardwaremanager` attribute:
 
-    nodeattrib n1-n4 pubkeys.tls_hardwaremanager=
-    
+```bash
+nodeattrib n1-n4 pubkeys.tls_hardwaremanager=
+```
+
 This can be combined with a configuration change.  For example, if we decide that the previous scheme of 10.2.3.{n1} really should be 10.2.4.{n1}:
 
-    nodeattrib n1-n42 hardwaremanagement.manager=10.2.4.{n1} pubkeys.tls_hardwaremanager=
+```bash
+nodeattrib n1-n42 hardwaremanagement.manager=10.2.4.{n1} pubkeys.tls_hardwaremanager=
+```
 
 This will change the desired ip address and reset the discovery process for those nodes
 to apply the requested change.

--- a/docs/user_reference/confluentrackview.md
+++ b/docs/user_reference/confluentrackview.md
@@ -1,8 +1,5 @@
 ---
 title: Setting up the confluent rackview
-layout: page
-permalink: /documentation/confluentrackview.html
-toc: true
 ---
 
 Confluent's web interface offers a rackview for rackmount and enclosure based systems. It can show where nodes are located in
@@ -17,11 +14,13 @@ recommended to also set location.height, as that will help the rackview draw mor
 
 Here is an example of how o2 was defined:
 
-    # nodeattrib o2 location.rack location.u location.row location.height
-    o2: location.height: 2
-    o2: location.rack: 4
-    o2: location.row: 1
-    o2: location.u: 32
+```bash
+# nodeattrib o2 location.rack location.u location.row location.height
+o2: location.height: 2
+o2: location.rack: 4
+o2: location.row: 1
+o2: location.u: 32
+```
 
 
 # Setting up an enclosure/dense system
@@ -31,14 +30,16 @@ should not have any location information, as their location will be defined by e
 
 Here is an example of a server (d1) inside an enclosure (smm1):
 
-    # nodeattrib d1 enclosure.manager enclosure.bay
-    d1: enclosure.bay: 1
-    d1: enclosure.manager: smm1
-    # nodeattrib smm1 location.rack location.u location.row location.height
-    smm1: location.height: 2
-    smm1: location.rack: 4
-    smm1: location.row: 1
-    smm1: location.u: 35
+```bash
+# nodeattrib d1 enclosure.manager enclosure.bay
+d1: enclosure.bay: 1
+d1: enclosure.manager: smm1
+# nodeattrib smm1 location.rack location.u location.row location.height
+smm1: location.height: 2
+smm1: location.rack: 4
+smm1: location.row: 1
+smm1: location.u: 35
+```
 
 
 

--- a/docs/user_reference/diskless_memory_usage.md
+++ b/docs/user_reference/diskless_memory_usage.md
@@ -1,3 +1,7 @@
+---
+title: Diskless memory usage
+---
+
 Memory usage of diskless has a number of factors to keep in mind.
 
 ## tethered (statelite)

--- a/docs/user_reference/el7deploy.md
+++ b/docs/user_reference/el7deploy.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: OS Deployment Notes for RedHat Enterprise Linux 7
-permalink: /documentation/el7deploy.html
 ---
 
 If executing genimage multiple times, it may be required to delete the image between runs. This

--- a/docs/user_reference/noderange.md
+++ b/docs/user_reference/noderange.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Noderange Syntax
-permalink: /documentation/noderange.html
 ---
 
 Confluent implements a powerful language to indicate a target
@@ -11,65 +9,89 @@ and set arithmetic.
 
 The simplest noderange is a single node name:
 
-	n1
+```bash
+n1
+```
 
 Nodes and groups may be used interchangeably.  The following may
 be used in any context where n1 would be accepted as a noderange:
 
-	rack1
+```bash
+rack1
+```
 
 Commonly, there is a desire to target a range of elements.  There are
 a few identically behaving syntaxes for the purpose.
 
-	n1:n20
-	n1-n20
-	n[1-20]
-	
+```bash
+n1:n20
+n1-n20
+n[1-20]
+```
+
 
 Note that numbers may be zero padded or not, it will automatically detect
 the padding amount and adjust members of the range accordingly.  Ranges
 also can understand multiple numeric values changing:
 
-	r[1-3]u[01-10]
-	r1u01-r3u10
+```bash
+r[1-3]u[01-10]
+r1u01-r3u10
+```
 
 Ranges can also be applied to group names, and all above syntaxes are compatible:
 
-	rack1-rack10
-	rack[1-10]
+```bash
+rack1-rack10
+rack[1-10]
+```
 
 Also, regular expressions may be used to indicate nodes with names matching certain patterns:
 
-	~r1u..
+```bash
+~r1u..
+```
 
 The other major noderange primitive is indicating nodes by some attribute value:
 
-	location.rack=7
+```bash
+location.rack=7
+```
 
 Commas can be used to indicate multiple nodes, and can mix and match any of the above primitives.  The following can be
 a valid single noderange, combining any and all members of each comma separated component
 
-	n1,n2,rack1,storage,location.rack=9,~s1..,n20-n30
+```bash
+n1,n2,rack1,storage,location.rack=9,~s1..,n20-n30
+```
 
 Exclusions can be done by prepending a '-' before a portion of a noderange:
 
-	rack1,-n2
-	compute,-rack1
-	compute,-location.row=12
+```bash
+rack1,-n2
+compute,-rack1
+compute,-location.row=12
+```
 
 To indicate nodes that match multiple selections at once (set intersection), the @ symbol may be used:
 
-	compute@rack1
-	location.rack=10@compute
+```bash
+compute@rack1
+location.rack=10@compute
+```
 
 For complex expressions, () may be used to indicate order of expanding the noderange to be explicit
 
-	rack1,-(console.logging=full@compute)
+```bash
+rack1,-(console.logging=full@compute)
+```
 
 Noderange syntax can also indicate 'pagination', or separating the nodes into well defined chunks.  > is used to indicate
 how many nodes to display at a time, and < is used to indicate how many nodes to skip into a noderange:
 
-	rack1>3<6
+```bash
+rack1>3<6
+```
 
 The above would show the seventh through ninth nodes of the rack1 group.  Like all other noderange operations, this may be combined
 with any of the above, but must appear as the very last operation.  Ordering is done with a natural sort.

--- a/docs/user_reference/osdeploy.md
+++ b/docs/user_reference/osdeploy.md
@@ -4,6 +4,31 @@ title: OS Deployment concepts
 
 Confluent supports a number of mechanisms for operating system deployment, with various benefits and drawbacks.
 
+## Supported operating systems
+
+Confluent recognizes the following operating system families when media is
+imported. The exact versions available as starting profiles depend on the
+media you import and the installed confluent release; newer point releases are
+generally detected automatically.
+
+| Family | Versions recognized |
+|--------|---------------------|
+| Enterprise Linux (RHEL, Rocky, AlmaLinux, CentOS Stream, Oracle Linux, openEuler) | 7, 8, 9, 10 |
+| Fedora | 41, 42 (handled as Enterprise Linux 10) |
+| SUSE Linux Enterprise / openSUSE Leap | 12, 15, 16 |
+| Ubuntu | 18.04, 20.04, 22.04 (and newer when a matching profile exists) |
+| Debian | 12 and newer |
+| VMware ESXi | Version detected from the install media |
+| Red Hat Virtualization Host (RHV-H) | 4.x |
+| Red Hat CoreOS / Fedora CoreOS | Version detected from the image |
+| Microsoft Windows | 2019, 2022, 2025 |
+| NVIDIA BlueField (DOCA/BFB) | Version detected from the BFB payload |
+
+!!! note
+    Recognition does not guarantee that every listed version ships a ready-made
+    sample profile. Importing media that confluent does not yet recognize will
+    report an unsupported-distribution error.
+
 ## Scripted install (stateful/diskful)
 
 The quickest to get started with is scripted install.  When importing OS install media, starting points for such profiles will be generated. This

--- a/docs/user_reference/osdeploy.md
+++ b/docs/user_reference/osdeploy.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: OS Deployment concepts
-permalink: /documentation/osdeploy.html
 ---
 
 Confluent supports a number of mechanisms for operating system deployment, with various benefits and drawbacks.

--- a/docs/user_reference/suse15deploy.md
+++ b/docs/user_reference/suse15deploy.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: OS Deployment Notes for SLE/SUSE 15
-permalink: /documentation/suse15deploy.html
 ---
 
 Note that if using xCAT and wanting to use the `reboot` postscript, it must be specified as

--- a/docs/user_reference/switchportattribs.md
+++ b/docs/user_reference/switchportattribs.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Configuring network port attributes
-permalink: /documentation/switchportattribs.html
 ---
 
 In xCAT and confluent, the [discovery process](confluentdiscovery.md) can use ethernet switch connectivity to assess real node identity to use in deploying configuration and gathering info such as mac addresses.

--- a/docs/user_reference/thermalpowerconfluent.md
+++ b/docs/user_reference/thermalpowerconfluent.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Power and Cooling Monitoring with Confluent
-permalink: /documentation/thermalpowerconfluent.html
 ---
 
 Confluent provides access to various power and cooling data on the monitored hardware.
@@ -13,8 +11,10 @@ as bash, or using an API (over the web, via python, or using the confetty CLI AP
 Exceptional thermal and power conditions warranting attention are provided by the `nodehealth` command, alongside
 conditions such as bad hardware components.
 
-	# nodehealth n507
-	n507: failed (Fan 1A Tach:0.0RPM,lower critical threshold,Fan 1B Tach:0.0RPM,lower critical threshold,Fan 2A Tach:0.0RPM,lower critical threshold,Fan 2B Tach:0.0RPM,lower critical threshold,Power Supply 1:Present,Failure,PS1 12Vaux Fault:Non-recoverable,Sys Boot Status:Boot error)
+```bash
+# nodehealth n507
+n507: failed (Fan 1A Tach:0.0RPM,lower critical threshold,Fan 1B Tach:0.0RPM,lower critical threshold,Fan 2A Tach:0.0RPM,lower critical threshold,Fan 2B Tach:0.0RPM,lower critical threshold,Power Supply 1:Present,Failure,PS1 12Vaux Fault:Non-recoverable,Sys Boot Status:Boot error)
+```
 
 This may include fan failures, bad temperature conditions, performance impact
 due to throttling, and so on.
@@ -22,8 +22,10 @@ due to throttling, and so on.
 For telemetry, the `nodesensors` command provides access to available power and
 cooling related data.  A key sensor of interest is the 'DC Energy' sensor:
 
-	# nodesensors n1 dc_energy
-	n1: DC Energy: 19.5191344589 kWh
+```bash
+# nodesensors n1 dc_energy
+n1: DC Energy: 19.5191344589 kWh
+```
 
 Using this value before and after some interval enables you to know the 
 kilowatt hours have been consumed over that time.  You can use this information
@@ -31,36 +33,44 @@ to calculate average power over an interval of your choosing.  For example, to
 know the average power before and after a 2 minute job (using sleep 120 as
 an example):
 
-	# nodesensors -c -n 1 n1 dc_energy; sleep 120; nodesensors -c -n 1 n1 dc_energy
-	time,node,DC Energy (kWh)
-	2016-10-17T10:39:37,n1,19.5271293078
-	time,node,DC Energy (kWh)
-	2016-10-17T10:41:37,n1,19.5294681086
+```bash
+# nodesensors -c -n 1 n1 dc_energy; sleep 120; nodesensors -c -n 1 n1 dc_energy
+time,node,DC Energy (kWh)
+2016-10-17T10:39:37,n1,19.5271293078
+time,node,DC Energy (kWh)
+2016-10-17T10:41:37,n1,19.5294681086
+```
 
 We take the difference in the kWh (0.0023388008) and divide by time elapsed in
 hours according to the timestamps (in bash, the timestamps may be subtracted):
 
-	# echo $((`date -d 2016-10-17T10:41:37 +%s`-`date -d 2016-10-17T10:39:37 +%s`))
-	120
+```bash
+# echo $((`date -d 2016-10-17T10:41:37 +%s`-`date -d 2016-10-17T10:39:37 +%s`))
+120
+```
 
 So we can use the change in kWh divided by the interval in hours (dividing
  seconds by 3600):
 
-	# echo 'scale=3;0.0023388008/(120/3600.0)'|bc
-	.070
+```bash
+# echo 'scale=3;0.0023388008/(120/3600.0)'|bc
+.070
+```
 
 This means the system used on average 0.070 kW (70 Watts) over the interval.
 
 Various other data is available under nodesensors.  For example, to retrieve
 all the temperature sensors in a system in CSV format over time for 5 seconds:
 
-	# nodesensors n721 temperature -c -i 1 -n 5
-	time,node,Ambient Temp (°C),CPU 1 OverTemp,CPU 2 OverTemp,CPU1 Temp (°C),CPU1 VR OverTemp,CPU2 Temp (°C),CPU2 VR OverTemp,GPU Outlet Temp (°C),HDD Inlet Temp (°C),PCH Temp (°C),PCI 2 Temp,PCI 3 Temp,PCI 4 Temp,PCI 5 Temp,PCI Riser 1 Temp (°C),PCI Riser 2 Temp (°C),PIB Ambient Temp (°C),Riser1 8764 Temp (°C),Riser2 8764 Temp (°C)
-	2016-10-17T11:28:07,n721,21.0,Ok,Ok,24.0,,26.0,,25.0,25.0,31.0,Ok,Ok,Ok,Ok,21.0,25.0,24.0,29.0,28.0
-	2016-10-17T11:28:08,n721,21.0,Ok,Ok,24.0,,26.0,,25.0,25.0,31.0,Ok,Ok,Ok,Ok,21.0,25.0,24.0,29.0,28.0
-	2016-10-17T11:28:09,n721,21.0,Ok,Ok,24.0,,26.0,,25.0,25.0,31.0,Ok,Ok,Ok,Ok,21.0,25.0,24.0,29.0,28.0
-	2016-10-17T11:28:10,n721,21.0,Ok,Ok,24.0,,27.0,,25.0,25.0,31.0,Ok,Ok,Ok,Ok,21.0,25.0,24.0,29.0,28.0
-	2016-10-17T11:28:11,n721,21.0,Ok,Ok,24.0,,27.0,,25.0,25.0,31.0,Ok,Ok,Ok,Ok,21.0,25.0,24.0,29.0,28.0
+```bash
+# nodesensors n721 temperature -c -i 1 -n 5
+time,node,Ambient Temp (°C),CPU 1 OverTemp,CPU 2 OverTemp,CPU1 Temp (°C),CPU1 VR OverTemp,CPU2 Temp (°C),CPU2 VR OverTemp,GPU Outlet Temp (°C),HDD Inlet Temp (°C),PCH Temp (°C),PCI 2 Temp,PCI 3 Temp,PCI 4 Temp,PCI 5 Temp,PCI Riser 1 Temp (°C),PCI Riser 2 Temp (°C),PIB Ambient Temp (°C),Riser1 8764 Temp (°C),Riser2 8764 Temp (°C)
+2016-10-17T11:28:07,n721,21.0,Ok,Ok,24.0,,26.0,,25.0,25.0,31.0,Ok,Ok,Ok,Ok,21.0,25.0,24.0,29.0,28.0
+2016-10-17T11:28:08,n721,21.0,Ok,Ok,24.0,,26.0,,25.0,25.0,31.0,Ok,Ok,Ok,Ok,21.0,25.0,24.0,29.0,28.0
+2016-10-17T11:28:09,n721,21.0,Ok,Ok,24.0,,26.0,,25.0,25.0,31.0,Ok,Ok,Ok,Ok,21.0,25.0,24.0,29.0,28.0
+2016-10-17T11:28:10,n721,21.0,Ok,Ok,24.0,,27.0,,25.0,25.0,31.0,Ok,Ok,Ok,Ok,21.0,25.0,24.0,29.0,28.0
+2016-10-17T11:28:11,n721,21.0,Ok,Ok,24.0,,27.0,,25.0,25.0,31.0,Ok,Ok,Ok,Ok,21.0,25.0,24.0,29.0,28.0
+```
 
 
 
@@ -74,79 +84,83 @@ for a general introduction to general usage of the API.
 Specifically, the sensors of interest are under the `/sensors/hardware/temperature` and `/sensors/hardware/power`
 categories.  Here is an example using curl to illustrate retrieving a single temperature on a single system:
 
-	# curl -u apiuser:apipassword http://localhost:4005/nodes/n721/sensors/hardware/temperature/cpu1_temp.json
-	{
-	    "_links": {
-		"collection": {
-		    "href": "./.json"
-		}, 
-		"self": {
-		    "href": "./cpu1_temp.json"
-		}
-	    }, 
-	    "sensors": [
-		{
-		    "health": "ok", 
-		    "name": "CPU1 Temp", 
-		    "state_ids": [], 
-		    "states": [], 
-		    "type": "Temperature", 
-		    "units": "°C", 
-		    "value": 24.0
-		}
-	    ]
+```bash
+# curl -u apiuser:apipassword http://localhost:4005/nodes/n721/sensors/hardware/temperature/cpu1_temp.json
+{
+    "_links": {
+	"collection": {
+	    "href": "./.json"
+	}, 
+	"self": {
+	    "href": "./cpu1_temp.json"
 	}
+    }, 
+    "sensors": [
+	{
+	    "health": "ok", 
+	    "name": "CPU1 Temp", 
+	    "state_ids": [], 
+	    "states": [], 
+	    "type": "Temperature", 
+	    "units": "°C", 
+	    "value": 24.0
+	}
+    ]
+}
+```
 
 As in all the confluent API, a single bulk request can be done against a noderange:
 
-	# curl -u apiuser:apipassword http://localhost:4005/noderange/n721-n723/sensors/hardware/temperature/cpu1_temp.json
-	{
-	    "_links": {
-		"collection": {
-		    "href": "./.json"
-		}, 
-		"self": {
-		    "href": "./cpu1_temp.json"
-		}
-	    }, 
-	    "databynode": [
-		{
-		    "n723": {
-			"error": "timeout"
-		    }
-		}, 
-		{
-		    "n722": {
-			"sensors": [
-			    {
-				"health": "ok", 
-				"name": "CPU1 Temp", 
-				"state_ids": [], 
-				"states": [], 
-				"type": "Temperature", 
-				"units": "°C", 
-				"value": 27.0
-			    }
-			]
-		    }
-		}, 
-		{
-		    "n721": {
-			"sensors": [
-			    {
-				"health": "ok", 
-				"name": "CPU1 Temp", 
-				"state_ids": [], 
-				"states": [], 
-				"type": "Temperature", 
-				"units": "°C", 
-				"value": 24.0
-			    }
-			]
-		    }
-		}
-	    ]
+```bash
+# curl -u apiuser:apipassword http://localhost:4005/noderange/n721-n723/sensors/hardware/temperature/cpu1_temp.json
+{
+    "_links": {
+	"collection": {
+	    "href": "./.json"
+	}, 
+	"self": {
+	    "href": "./cpu1_temp.json"
 	}
+    }, 
+    "databynode": [
+	{
+	    "n723": {
+		"error": "timeout"
+	    }
+	}, 
+	{
+	    "n722": {
+		"sensors": [
+		    {
+			"health": "ok", 
+			"name": "CPU1 Temp", 
+			"state_ids": [], 
+			"states": [], 
+			"type": "Temperature", 
+			"units": "°C", 
+			"value": 27.0
+		    }
+		]
+	    }
+	}, 
+	{
+	    "n721": {
+		"sensors": [
+		    {
+			"health": "ok", 
+			"name": "CPU1 Temp", 
+			"state_ids": [], 
+			"states": [], 
+			"type": "Temperature", 
+			"units": "°C", 
+			"value": 24.0
+		    }
+		]
+	    }
+	}
+    ]
+}
+```
 
 
 

--- a/docs/user_reference/ubuntudeploy.md
+++ b/docs/user_reference/ubuntudeploy.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: OS Deployment Notes for Ubuntu 
-permalink: /documentation/ubuntudeploy.html
 ---
 
 <b>Troubleshooting name resolution issues</b>  

--- a/docs/user_reference/updatesw_rhel.md
+++ b/docs/user_reference/updatesw_rhel.md
@@ -1,12 +1,12 @@
 ---
-layout: page
 title: Applying software updates to RedHat/CentOS
-permalink: /documentation/updatesw_rhel.html
 ---
 
 After adding the correct repository as indicated in the [download page](../downloads.md), you can
 update all the software provided by the repository using yum.  If you want to restrict updates only to the HPC
 related software, you may instruct yum to do so by:
 
-    yum --disablerepo=* --enablerepo=lenovo-hpc update
+```bash
+yum --disablerepo=* --enablerepo=lenovo-hpc update
+```
 


### PR DESCRIPTION
Repo-wide documentation upgrade. No source content lost; site builds cleanly (mkdocs build, 142 pages). See CHANGELOG.md for details.

- Remove dead Jekyll front matter (layout/permalink/toc) from 89 pages, preserving title and blog date/draft front matter
- Rebuild index.md as a modern Material landing page with card-grid entry points
- Add curated .nav.yml navigation (titled sections, logical ordering)
- Convert indented code blocks to fenced+language across getting_started, user_reference, and troubleshooting (syntax highlighting + copy button)
- Fix broken links (proxmox images, switchtonginx, nokia release note) and spelling typos
- Remove two empty stub pages and add titles to untitled pages