### PR TITLE
Modernize features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _site
 docs/user_reference/node_attributes.md
 docs/manuals/*.md
 confluent
+.venv/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to the confluent documentation are recorded here.
 
+## Site feature modernization
+
+Enabled several Material for MkDocs capabilities.
+
+### Added
+- **Tags**: a tag taxonomy with a `tags.md` index page, seeded across key pages
+  (deployment, installation, discovery, networking, hardware, diskless,
+  security, collective, reference, api).
+- **RSS feed** for the release-notes blog (`mkdocs-rss-plugin`).
+- **Image zoom** on screenshots via `mkdocs-glightbox`.
+- **Mermaid diagram support** via a `pymdownx.superfences` custom fence
+  (` ```mermaid ` blocks now render as diagrams).
+- **Social cards**: the Material `social` plugin, configured but dormant
+  (`enabled: !ENV [SOCIAL_CARDS, false]`). It activates only when the
+  `SOCIAL_CARDS` env var is set, so local and CI builds are unaffected until a
+  maintainer opts in. Enabling also requires the Cairo system libraries and the
+  `pillow` + `cairosvg` packages (already in `requirements.txt`).
+
+### Notes
+- The four architecture diagrams currently shipped as SVGs
+  (`hierarchy`, `redundant_hierarchy`, `segmented`, `flat`) could be migrated
+  to inline Mermaid now that the capability is enabled; left as a follow-up
+  since it requires re-authoring the diagram source.
+- Enabling social cards needs a small CI change (install Cairo libs + set
+  `SOCIAL_CARDS`); not made here because the access token used lacked the
+  `workflow` scope to modify `.github/workflows/`.
+
 ## Heading and prose cleanup
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to the confluent documentation are recorded here.
 
+## Heading and prose cleanup
+
+### Changed
+- Normalized heading levels so each page has a single H1 (the page title) with
+  sections at H2 and below, fixing pages that used multiple H1 headings for
+  sections (which broke the on-page table of contents).
+- Converted legacy setext (`====` / `----`) headings to ATX (`#` / `##`).
+
+### Added
+- Converted standalone "Note that ..." paragraphs to Material `!!! note`
+  admonitions for better scannability.
+
+### Fixed
+- Spelling typos (pseudo, governed, existence, consumption, arbitrarily,
+  supported, minimum, Subiquity).
+
 ## Code-block modernization
 
 Completed the code-block conversion begun in the documentation revamp.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to the confluent documentation are recorded here.
 
+## Code-block modernization
+
+Completed the code-block conversion begun in the documentation revamp.
+
+### Changed
+- Converted indented code blocks to fenced blocks with a language hint across
+  the remaining hand-written pages in `advanced_topics/` (13 pages),
+  `miscellaneous/` (9 pages), `developer/api.md`, and `downloads.md` - enabling
+  syntax highlighting and the copy-to-clipboard button to match the rest of the
+  site. Pages whose indentation is prose/list layout (e.g.
+  `miscellaneous/samplepostscripts.md`) and the generated `manuals/` pages were
+  intentionally left unchanged.
+
+## Code-verified content updates
+
+A pass cross-checking the documentation against the confluent source code
+(`xcat2/confluent`) and correcting stale or missing content. Every change below
+was verified against the code.
+
+### Added
+- `user_reference/osdeploy.md`: a "Supported operating systems" section
+  reflecting the OS families and versions the current code recognizes (Enterprise
+  Linux 7-10, SUSE/openSUSE 12/15/16, Ubuntu, Debian 12+, VMware ESXi, RHV-H,
+  Red Hat/Fedora CoreOS, Windows 2019/2022/2025, openEuler, Fedora, NVIDIA
+  BlueField), based on `confluent_server/confluent/osimage.py` and the
+  `confluent_osdeploy` profile directories.
+- `developer/api.md`: a top-level collections overview matching the API root in
+  `core.py`, a real discovery section (replacing a commented-out stub), and
+  documentation for previously undocumented resources (PDU power inlets/outlets,
+  graphical/iKVM console, per-node deployment, storage configuration, management
+  controller licenses/certificates, firmware subcategories, support servicedata).
+- Man pages (in the `confluent` source repo, `confluent_client/doc/man/`) for
+  seven client commands that shipped without documentation: `noderename`,
+  `nodegrouprename`, `confluent2ansible`, `confluent2xcat`, `confluent2lxca`,
+  `dir2img`, and `nodecertutil`.
+
+### Fixed
+- `developer/api.md`: corrected the remote HTTP API port from `14005` to `4005`,
+  the actual default bind port in `confluent_server` `httpapi.py`, and removed
+  author-only TODO and scratch comments left in the published page.
+
 ## Documentation revamp
 
 A repo-wide modernization of the MkDocs Material documentation. No source

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -9,3 +9,4 @@ nav:
   - Developer: developer
   - Downloads: downloads.md
   - Release Notes: release_notes
+  - Tags: tags.md

--- a/docs/advanced_topics/collective.md
+++ b/docs/advanced_topics/collective.md
@@ -6,14 +6,14 @@ The collective mode of confluent allows multiple confluent servers to act as one
 both high availability as well as scaling out to cover a larger number of servers with better
 performance.
 
-# Shared storage considerations
+## Shared storage considerations
 
 For operating system deployment, it is expected that /var/lib/confluent be identical across all
 collective members.  This may through use of an NFS mount, clustered filesystem, or synchronized
 local filesystem content. Confluent has no particular requirements of how this is done, but does
 expect it to be identical if OS deploymennt features are used.
 
-# Creating a collective
+## Creating a collective
 
 To begin, select a confluent server to begin constructing the collective from.  This page will use `mgt1`
 as the server to start from.  All other
@@ -43,7 +43,7 @@ Active collective members:
     mgt2
 ```
 
-Note that a two server collective is actually not redundant, as a minimun of 3 servers is required for redundancy.  Any member of a collective
+Note that a two server collective is actually not redundant, as a minimum of 3 servers is required for redundancy.  Any member of a collective
 can invite an additional member.  For example, extending the collective above to include mgt3 could be done from mgt1, but we will do it from mgt2
 in this case:
 
@@ -63,7 +63,7 @@ Active collective members:
     mgt3
 ```
 
-# OS Deployment considerations
+## OS Deployment considerations
 
 OS Deployment initialization (`osdeploy initialize`) operations must be done once per collective member to
 properly enable each member to provide deployment services to nodes.  For the SSH material (automation (-a) and CA (-s)), it
@@ -73,7 +73,7 @@ run osdeploy initialize -ask.
 Further, after adding a new collective member and performing collective initialize on the new host,
 run osdeploy initialize -k on all other hosts to trust the new collective member's SSH certificate authority.
 
-# Managing the nodes' active manager
+## Managing the nodes' active manager
 
 Once in a collective, each managed system must have a designated manager.  This can be changed on the fly.  If unspecified and a node goes through the discovery process, the member that performs the discovery claims the node by default. Additionally, automatic assignment in event of the collective.manager failing
 can be requested by setting `collective.managercandidates` which accepts a noderange of collective members to take over management in the case of
@@ -87,15 +87,16 @@ for a node or a group.  Issuing the same commands with different collective.mana
 # nodegroupattrib rack1 collective.manager=mgt1
 ```
 
-# Restoring a missing collective member by repeating the invite process
+## Restoring a missing collective member by repeating the invite process
 
 At any point, the invite process can be repeated for a member as if it were joining new, and it will replace the stale entry.
 
-# Limitations
+## Limitations
 
-Note that currently most functions are enabled to be identical across a collective,
-however /networking and /discovery apis are currently distinct per collective member.  This means
-that nodediscover commands and automatic discovery activity must be directly managed on the respective
-collective member.
+!!! note
+    Currently most functions are enabled to be identical across a collective,
+    however /networking and /discovery apis are currently distinct per collective member.  This means
+    that nodediscover commands and automatic discovery activity must be directly managed on the respective
+    collective member.
 
 Also note that all members of a collective must be running the same version of confluent and pyghmi.

--- a/docs/advanced_topics/collective.md
+++ b/docs/advanced_topics/collective.md
@@ -20,40 +20,48 @@ as the server to start from.  All other
 confluent servers will lose their configuration and the starting server configuration will replace it.
 On this server, generate an invitation for another server:
 
-    [root@mgt1 ~]# collective invite mgt2
-    bWd0MkD/e95FBKP6NrBP4VSZFbZkwDmH5XqiIi8kpf3B0hGWuP6bfAcimUrs/7mKfI78+sGOHz7+YFg5zBm7Ubzzpx2j
+```bash
+[root@mgt1 ~]# collective invite mgt2
+bWd0MkD/e95FBKP6NrBP4VSZFbZkwDmH5XqiIi8kpf3B0hGWuP6bfAcimUrs/7mKfI78+sGOHz7+YFg5zBm7Ubzzpx2j
+```
 
 On mgt2, use the data above to join the collective:
 
-    [root@mgt2 ~]# collective join mgt1 -i bWd0MkD/e95FBKP6NrBP4VSZFbZkwDmH5XqiIi8kpf3B0hGWuP6bfAcimUrs/7mKfI78+sGOHz7+YFg5zBm7Ubzzpx2j
-    Certificate generated successfully
-    Success
+```bash
+[root@mgt2 ~]# collective join mgt1 -i bWd0MkD/e95FBKP6NrBP4VSZFbZkwDmH5XqiIi8kpf3B0hGWuP6bfAcimUrs/7mKfI78+sGOHz7+YFg5zBm7Ubzzpx2j
+Certificate generated successfully
+Success
+```
 
 On any member, `collective show` will show current status of the collective:
 
-    [root@mgt2 ~]# collective show
-    Quorum: True
-    Leader: mgt1
-    Active collective members:
-        mgt2
+```bash
+[root@mgt2 ~]# collective show
+Quorum: True
+Leader: mgt1
+Active collective members:
+    mgt2
+```
 
 Note that a two server collective is actually not redundant, as a minimun of 3 servers is required for redundancy.  Any member of a collective
 can invite an additional member.  For example, extending the collective above to include mgt3 could be done from mgt1, but we will do it from mgt2
 in this case:
 
-    [root@mgt2 ~]# collective invite mgt3
-    bWd0M0Bur9G7oFs31jkHiNeFNIoMI7lz8O354e7OhJ5Scqq6goztkoZsSnThbNxih45c3UYs5vc33F1gJ8XX+9FJCw51
+```bash
+[root@mgt2 ~]# collective invite mgt3
+bWd0M0Bur9G7oFs31jkHiNeFNIoMI7lz8O354e7OhJ5Scqq6goztkoZsSnThbNxih45c3UYs5vc33F1gJ8XX+9FJCw51
 
-    [root@mgt3 ~]# collective join mgt2 -i bWd0M0Bur9G7oFs31jkHiNeFNIoMI7lz8O354e7OhJ5Scqq6goztkoZsSnThbNxih45c3UYs5vc33F1gJ8XX+9FJCw51
-    Certificate generated successfully
-    Success
-    
-    [root@mgt3 ~]# collective show
-    Quorum: True
-    Leader: mgt1
-    Active collective members:
-        mgt2
-        mgt3
+[root@mgt3 ~]# collective join mgt2 -i bWd0M0Bur9G7oFs31jkHiNeFNIoMI7lz8O354e7OhJ5Scqq6goztkoZsSnThbNxih45c3UYs5vc33F1gJ8XX+9FJCw51
+Certificate generated successfully
+Success
+
+[root@mgt3 ~]# collective show
+Quorum: True
+Leader: mgt1
+Active collective members:
+    mgt2
+    mgt3
+```
 
 # OS Deployment considerations
 
@@ -74,8 +82,10 @@ the current manager going out.
 Here are examples of setting it
 for a node or a group.  Issuing the same commands with different collective.manager is all that is required to move a node.
 
-    # nodeattrib n1 collective.manager=mgt1
-    # nodegroupattrib rack1 collective.manager=mgt1
+```bash
+# nodeattrib n1 collective.manager=mgt1
+# nodegroupattrib rack1 collective.manager=mgt1
+```
 
 # Restoring a missing collective member by repeating the invite process
 

--- a/docs/advanced_topics/collective.md
+++ b/docs/advanced_topics/collective.md
@@ -1,5 +1,7 @@
 ---
 title: Confluent collective mode
+tags:
+  - collective
 ---
 
 The collective mode of confluent allows multiple confluent servers to act as one, providing

--- a/docs/advanced_topics/confluentdiscoverysetting.md
+++ b/docs/advanced_topics/confluentdiscoverysetting.md
@@ -24,4 +24,5 @@ In order to define the value of the setting for a particular Confluent managemen
 enabled: False
 ```
 
-Note that the setting defaults to "True".
+!!! note
+    The setting defaults to "True".

--- a/docs/advanced_topics/confluentdiscoverysetting.md
+++ b/docs/advanced_topics/confluentdiscoverysetting.md
@@ -10,14 +10,18 @@ The setting must be defined for each Confluent management node, including all me
 
 In order to view the current value of the setting for a particular Confluent management node, run the following command locally:
 
-    # confetty show discovery/autosense
-    enabled: True
+```bash
+# confetty show discovery/autosense
+enabled: True
+```
 
 In order to define the value of the setting for a particular Confluent management node, run the following command locally:
 
-    # confetty set discovery/autosense enabled=False
+```bash
+# confetty set discovery/autosense enabled=False
 
-    # confetty show discovery/autosense
-    enabled: False
+# confetty show discovery/autosense
+enabled: False
+```
 
 Note that the setting defaults to "True".

--- a/docs/advanced_topics/confluentenclosuredisco.md
+++ b/docs/advanced_topics/confluentenclosuredisco.md
@@ -8,18 +8,24 @@ of how location based discovery should go.
 For the SD530, ensure that `enclosure.manager` indicates a node meant to represent the SMM in the chassis, and
 that `enclosure.bay`  is set to indicate the bay in the chassis. For example:
 
-    # nodeattrib n1 enclosure.manager=smm1 enclosure.bay=1
+```bash
+# nodeattrib n1 enclosure.manager=smm1 enclosure.bay=1
+```
 
 As with all attributes, this may be set at group level using formulaic expansion to vary the values per node if desired.
 
 The SMM node could in turn have `net.switch` and `net.switchport` set according to its location if directly connected to switches:
 
-    # nodeattrib smm1 net.switch=r4e1 net.switchport=35
+```bash
+# nodeattrib smm1 net.switch=r4e1 net.switchport=35
+```
 
 For chained enclosures, for all enclosures not directly connected to the switch, use the `enclosure.extends` to indicate the next
 enclosure the SMM would need to use to reach the switch:
 
-    # nodeattrib smm2 enclosure.extends=smm1
-    # nodeattrib smm3 enclosure.extends=smm2
+```bash
+# nodeattrib smm2 enclosure.extends=smm1
+# nodeattrib smm3 enclosure.extends=smm2
+```
 
 With that, discovery will proceed identically to the procedure in [using switch based discovery](confluentswitchdisco.md)

--- a/docs/advanced_topics/confluentnodeassign.md
+++ b/docs/advanced_topics/confluentnodeassign.md
@@ -2,10 +2,11 @@
 title: Manual discovery with nodediscover assign
 ---
 
-Note that discovery in confluent is an optional process intended to aid with automatic gathering of mac addresses,
-configuring IP addresses and authentication of management controllers (e.g. xClarity Controller) when they may not have
-a viable or known IP address. If wanting to use confluent in an environment where the onboarding is otherwise handled,
-you may want to skip ahead to [managing hardware using confluent](../miscellaneous/manageconfluent.md).
+!!! note
+    Discovery in confluent is an optional process intended to aid with automatic gathering of mac addresses,
+    configuring IP addresses and authentication of management controllers (e.g. xClarity Controller) when they may not have
+    a viable or known IP address. If wanting to use confluent in an environment where the onboarding is otherwise handled,
+    you may want to skip ahead to [managing hardware using confluent](../miscellaneous/manageconfluent.md).
 
 Once parameters have been [configured](../getting_started/configureconfluent.md) such as desired username and password,
 discovery can be performed to push that configuration from the confluent configuration into the actual configuration on the devices.
@@ -14,7 +15,7 @@ Confluent is capable of fully automated onboarding of equipment based on either 
 this would require things that are either not applicable, not known, or not allowed. In such circumstancecs, there are manual
 methods to aid in simplified onboarding kicked off by manual data despite those devices still not yet having viable configuration.
 
-# Showing currently known data
+## Showing currently known data
 
 By default confluent is always trying to passively gather data about a network. It is however prudent to request that confluent actively scan the environment to recognize new devices or update stale information.  If wanting to purge all data to ensure no stale data
 is visible, clearing the discovery information can be done by executing:
@@ -47,7 +48,7 @@ Further attributes may be defined on this line, in this example we are taking ad
 
 The specified node at this point can be [managed by confluent](../miscellaneous/manageconfluent.md).
 
-# Bulk manual discovery
+## Bulk manual discovery
 
 The `nodediscover` command can accept a csv file of data and handle defining and associating devices. Here we will use nodediscover
 list to create a starting point:
@@ -79,8 +80,9 @@ add a `bmc` column to the CSV to specify the desired IP (which need not be the s
     DVJJ1042,n3,172.30.170.3
     DVJJ1003,n4,172.30.170.4
 
-Note that if you receive an error like `Nodename is a required field`, check for any completely blank lines, for example at the
-end of the file. Delete any such lines and try again.
+!!! note
+    If you receive an error like `Nodename is a required field`, check for any completely blank lines, for example at the
+    end of the file. Delete any such lines and try again.
     
 
 This file can be processed by nodediscover to associate all the serial numbers with node names:

--- a/docs/advanced_topics/confluentosdeploy.md
+++ b/docs/advanced_topics/confluentosdeploy.md
@@ -31,11 +31,11 @@ Again, if root login by password is desired (if unspecified, only key based logi
 
 Keep in mind that the OS being deployed may prohibit ssh password login by root as a default, see `PermitRootLogin` in sshd_config for your distribution for more details.
 
-# IPv6 configuration
+## IPv6 configuration
 
 Deployment interfaces must have IPv6 enabled, with at least an automatic fe80:: address.  Generally this is default network interface configuration.  IPv6 need only be enabled, it need not be given any address manually, by DHCP, or by route advertisements, the automatic fe80:: addresses suffice.  Full IPv6 and IPv6 exclusive deployment is supported if desired, but even a "pure" IPv4 network will leverage the automatic IPv6 fe80:: for some key features.
 
-# Name resolution (optional)
+## Name resolution (optional)
 
 An existing or otherwise manually configured DNS solution is fine for a confluent managed cluster. If such a solution is unavailable, this section provides a strategy to quickly generate IP addresses and use
 `dnsmasq` as a name server.
@@ -69,7 +69,7 @@ With an /etc/hosts appropriately generated, use the package management software 
 If /etc/hosts is updated, restart dnsmasq, as dnsmasq does not automatically update on update of /etc/hosts.
 
 
-# DHCP (optional)
+## DHCP (optional)
 
 DHCP is not required or if present, may be externally managed.  Skip this section if either a DHCP server is already in place or if there is no requirement for a dynamic pool of DHCP addresses on the network.  Confluent will not require any DHCP dynamic range if one is not available.  However, if wanting to provide a dynamic DHCP range for various devices that may also exist on the network, `dnsmasq` can provide that functionality.  If using `dnsmasq` on the same system as confluent for DHCP function, add the following to /etc/dnsmasq.conf to allow both dnsmasq and confluent to share the network:
 
@@ -85,7 +85,7 @@ If using a dynamic range on a network, instruct confluent to use `firmwaredhcp` 
 
     # nodegroupattrib everything net.ipv4_method=firmwaredhcp
 
-# Having a Genesis network boot environment (optional)
+## Having a Genesis network boot environment (optional)
 
 The 'genesis' image is a very small network booted linux environment for servicing/rescue.  When deployed, the node can run linux commands and can be sshed into as if it
 were a normal OS, but it won't touch any disks.
@@ -96,7 +96,7 @@ the package `confluent-genesis-x86_64` if a genesis profile is desired.
 `osdeploy initialize` (see next step) has an option to generate a genesis profile. Once used, a genesis based profile would be in /var/lib/confluent/public/os/genesis-x86_64/.  Of particular interest is the
 `/var/lib/confluent/public/os/gensis-x86_64/scripts/onboot.sh` file to govern automatic action, or use ssh after nodes boot to manually perform actions.
 
-# Preparing for TFTP (optional)
+## Preparing for TFTP (optional)
 
 Note that confluent now supports both PXE and HTTP Boot. If using purely HTTP boot, then you do not need a tftp server at all. Additionally, 
 Secureboot is only fully supported with HTTP Boot. To support
@@ -106,14 +106,14 @@ clients that are PXE booting, ensure that tftp is installed.  Note that xCAT may
 
 `osdeploy initialize` in an upcoming step will help initialize needed tftp content.
 
-# Configuring nodes for HTTP Boot (optional)
+## Configuring nodes for HTTP Boot (optional)
 
 If wanting to use HTTP Boot instead, here is an example to configure Lenovo systems to use HTTP instead of PXE boot:
 
     # nodeconfig d3-d6 NetworkStackSettings.IPv4PXESupport=disable NetworkStackSettings.IPv4HTTPSupport=enable
 
 
-# Initializing OS deployment configuration
+## Initializing OS deployment configuration
 
 The `osdeploy initialize` command is used to prepare a confluent server to deploy operating systems.  For first time setup, run osdeploy initialize interactively to be walked through the various options:
 
@@ -122,7 +122,7 @@ The `osdeploy initialize` command is used to prepare a confluent server to deplo
 Every option provides a command line flag to use instead of -i if wanting to run osdeploy initialize in a non-interactive fashion opting into the specified options.
 
 
-# Importing an install source from media
+## Importing an install source from media
 
 The `osdeploy import` is used to take recognized installation media and produce stock OS deployment profiles:
 
@@ -131,7 +131,7 @@ The `osdeploy import` is used to take recognized installation media and produce 
     complete: 100.00%    
     Deployment profile created: rhel-8.2-x86_64-default
 
-# Customizing or copying a profile
+## Customizing or copying a profile
 
 A deployment profile is simply the collection of files in /var/lib/confluent/public/os/<profilename>.  The stock profile may be edited in place, however to create a copy for customization, it is as straightforward as:
 
@@ -142,7 +142,8 @@ A deployment profile is simply the collection of files in /var/lib/confluent/pub
 
 For Ubuntu profiles, you also need to modify profile.yaml to update the profile name embedded in the kernel arguments, and then run `osdeploy updateboot newprofilenamehere`.
 
-Note that not all profiles contain private data, by default diskless images and captured clones have an encryption key in private, but scripted installs do not. Further note that a profile name may experience problems if the profile name is longer than 73 characters.
+!!! note
+    Not all profiles contain private data, by default diskless images and captured clones have an encryption key in private, but scripted installs do not. Further note that a profile name may experience problems if the profile name is longer than 73 characters.
 
 If having a lot of shared content, it may be wise to employ symbolic links to explicitly share content rather than creating several copies of the same content (scripts or otherwise). It may also be a good idea to use git to manage and track changes as well.
 
@@ -164,7 +165,7 @@ Skipping update of scripts/firstboot.sh as current copy was customized or no man
 
 
 
-# Specifying custom postscripts or ansible plays
+## Specifying custom postscripts or ansible plays
 
 A number of phases are opened up for injecting custom scripts or ansible plays.  Scripts are executed directly on the deployment server while ansible plays are executed by the deployment server targeting
 the deploying system as if it were specified as a host in the play.
@@ -187,13 +188,13 @@ For diskless installs, scripts/onboot.d is available.  Note that content under /
 
 Additionally check files like kickstart.custom in the top level directory for some suggested alterations.
 
-# Handling xClarity Controller or TSM on shared ports (on board network or OCP)
+## Handling xClarity Controller or TSM on shared ports (on board network or OCP)
 
 If wanting to move the xClarity Controller or TSM to be accessed over a port shared with the operating system, see either `pre.custom` of an install profile or `onboot.sh` of the genesis profile for examples of how to
 incorporate `configbmc` into a Genesis boot or an install. This will move the network port to allow out of band discovery to continue and set username
 and password remotely.
 
-# Requesting os deployment
+## Requesting os deployment
 
 Even before discovery, nodedeploy is able to request that the next boot be into a profile:
 
@@ -204,28 +205,29 @@ After the xClarity Controller or equivalents are accesible, it can also initiate
     # nodedeploy <nodes> -n rhel-8.2-x86_64-default
 
 
-# Requesting node identifiers from nodeinventory
+## Requesting node identifiers from nodeinventory
 
 If discovery has been skipped and a BMC has been added manually, then the following command will populate attributes needed for deployment for most scenarios:
 
     # nodeinventory node -s
 
-# Manually indicating node identifiers
+## Manually indicating node identifiers
 
 For many users, node identifiers will be automatically gathered by node discovery process.  However, the discovery process is optional, and if
 not wanting to use the process, or using servers that are not supported by the discovery process, then it is possible to feed the data into the requisite attributes rather than using a discovery process.  For a MAC address:
 
     # nodeattrib node net.hwaddr=00:01:02:03:04:05
 
-Note that in discovery, we tend to prefer the UUID, as it makes the boot process the most adaptive for dealing with multi-nic booting with only a single identifier.  It's also more commonly available
-in nodeinventory across systems.  However, for certain non-Lenovo systems, the UUID may not be reliable and the MAC address can be used.  Also if MAC addresses are more familiar, they may be used.
+!!! note
+    In discovery, we tend to prefer the UUID, as it makes the boot process the most adaptive for dealing with multi-nic booting with only a single identifier.  It's also more commonly available
+    in nodeinventory across systems.  However, for certain non-Lenovo systems, the UUID may not be reliable and the MAC address can be used.  Also if MAC addresses are more familiar, they may be used.
 
 
 Alternatively, a system UUID may be used instead:
 
     # nodeattrib node id.uuid=c70998ec-0585-45da-85f0-f06717ec97e6
 
-# Next steps
+## Next steps
 
 With OS deployment ready, depending on circumstances it may be appropriate to move on to:
 

--- a/docs/advanced_topics/confluentswitchdisco.md
+++ b/docs/advanced_topics/confluentswitchdisco.md
@@ -15,30 +15,38 @@ For cumulus switches, install the affluent agent as documented in ['Using a Cumu
 
 Adding an ethernet switch is done simply by adding the IP or a name that resolves to the switch:
 
-    # nodedefine r4e1 type=switch
+```bash
+# nodedefine r4e1 type=switch
+```
 
 If the username and password are not inherited from a group like everything, be sure to set the username and password:
 
-    # nodeattrib r4e1 -p switchuser switchpass
+```bash
+# nodeattrib r4e1 -p switchuser switchpass
+```
 
 With the switch added, run:
 
-    # nodediscover rescan
+```bash
+# nodediscover rescan
+```
 
 Watching `/var/log/confluent/events` should indicate any problems that may be encountered.
 
 With that, the `nodediscover` command now can present data about network connectivity:
 
-    # nodediscover list -f model,serial,type,mac,switch,port -o port | grep -v lenovo-switch| head 
-          Model|     Serial|          Type|               Mac| Switch|       Port
-    -----------|-----------|--------------|------------------|-------|-----------
-        5466AC1|    DVJICDA|   lenovo-imm2| 40:f2:e9:75:1f:bd|   r4e1| Ethernet14
-        5463AC1|    DVJPDPM|   lenovo-imm2| 40:f2:e9:b9:10:1d|   r4e1| Ethernet17
-        5462AC1|    DVJ3821|   lenovo-imm2| 40:f2:e9:af:45:a5|   r4e1| Ethernet27
-     7Z01CTOLWW|   DVJ328J5|    lenovo-tsm| 3c:e1:a1:c7:ea:79|   r4e1| Ethernet29
-     7Y0XCTOLWW|   DVJJ3891|    lenovo-tsm| 3c:e1:a1:c7:e6:27|   r4e1| Ethernet32
-     7Y02CTOLWW|   DVJJ8699|    lenovo-xcc| 08:94:ef:49:c3:55|   r4e1| Ethernet34
-     7X21CTOLWW|   DVJJ1086|    lenovo-xcc| 08:94:ef:2f:2e:9d|   r4e1| Ethernet35
+```bash
+# nodediscover list -f model,serial,type,mac,switch,port -o port | grep -v lenovo-switch| head 
+      Model|     Serial|          Type|               Mac| Switch|       Port
+-----------|-----------|--------------|------------------|-------|-----------
+    5466AC1|    DVJICDA|   lenovo-imm2| 40:f2:e9:75:1f:bd|   r4e1| Ethernet14
+    5463AC1|    DVJPDPM|   lenovo-imm2| 40:f2:e9:b9:10:1d|   r4e1| Ethernet17
+    5462AC1|    DVJ3821|   lenovo-imm2| 40:f2:e9:af:45:a5|   r4e1| Ethernet27
+ 7Z01CTOLWW|   DVJ328J5|    lenovo-tsm| 3c:e1:a1:c7:ea:79|   r4e1| Ethernet29
+ 7Y0XCTOLWW|   DVJJ3891|    lenovo-tsm| 3c:e1:a1:c7:e6:27|   r4e1| Ethernet32
+ 7Y02CTOLWW|   DVJJ8699|    lenovo-xcc| 08:94:ef:49:c3:55|   r4e1| Ethernet34
+ 7X21CTOLWW|   DVJJ1086|    lenovo-xcc| 08:94:ef:2f:2e:9d|   r4e1| Ethernet35
+```
 
 The data can be used to guide a manual discovery, but nodes may also be defined to automatically configure devices based on
 where they are plugged in. This can either be based on where the management controller is connected (recommended
@@ -47,46 +55,56 @@ to execute a network boot (required for scenarios where the management controlle
 operating system). If using the network boot port, then discovery is delayed until PXE boot is attempted. For example,
 here is a node that has a TSM connected to switch port 29 of a switch:
 
-    # nodedefine example1 net.switch=r4e1 net.switchport=29 discovery.policy=permissive,pxe
-    example1: created
-    # nodediscover rescan
-    Rescan complete
+```bash
+# nodedefine example1 net.switch=r4e1 net.switchport=29 discovery.policy=permissive,pxe
+example1: created
+# nodediscover rescan
+Rescan complete
+```
 
 When specifying switches and net.switch value, ensure the attribute values match. Do not use IP
 in one place and a DNS name in the other, for example.
 
 Results can be seen by following `/var/log/confluent/events` or by watching `nodediscover list`:
 
-    # grep example1 /var/log/confluent/events
-    Sep 02 13:53:51 {"info": "Discovered example1 (TSM)"}
-    # nodediscover list -f node,model,serial,mac|egrep 'J100GZG5|Node|----'
-         Node|      Model|     Serial|               Mac
-    ---------|-----------|-----------|------------------
-     example1| 7Z01CTO1WW|   J100GZG5| 3c:e1:a1:c7:ea:79
+```bash
+# grep example1 /var/log/confluent/events
+Sep 02 13:53:51 {"info": "Discovered example1 (TSM)"}
+# nodediscover list -f node,model,serial,mac|egrep 'J100GZG5|Node|----'
+     Node|      Model|     Serial|               Mac
+---------|-----------|-----------|------------------
+ example1| 7Z01CTO1WW|   J100GZG5| 3c:e1:a1:c7:ea:79
+```
 
 Once the node has reported as 'Discovered', commands may be run against the node:
 
-    # nodehealth example1
-    example1: ok
+```bash
+# nodehealth example1
+example1: ok
+```
 
 To scale out such a strategy to a structured environment easily, it makes sense to take advantage of the group inheritance
 and formulaic expansion.  In this example, we will have a name scheme of r{rack}u{u in rack} and we will plug u1 into port 1, u 2 in port 2, and so on:
 
-    # nodegroupdefine rackmount net.switch=r{n1}e1 net.switchport={n2}
-    # nodedefine r4u29 groups=rackmount
-    # nodeattrib r4u29 net.switch net.switchport --blame
-    r4u29: net.switch: r4e1 (inherited from group rackmount, derived from expression "r{n1}e1")
-    r4u29: net.switchport: 29 (inherited from group rackmount, derived from expression "{n2}")
-    # nodediscover rescan
-    Rescan complete
+```bash
+# nodegroupdefine rackmount net.switch=r{n1}e1 net.switchport={n2}
+# nodedefine r4u29 groups=rackmount
+# nodeattrib r4u29 net.switch net.switchport --blame
+r4u29: net.switch: r4e1 (inherited from group rackmount, derived from expression "r{n1}e1")
+r4u29: net.switchport: 29 (inherited from group rackmount, derived from expression "{n2}")
+# nodediscover rescan
+Rescan complete
+```
 
 As above, after some time the node may be seen in nodediscover list or `/var/log/confluent/events`
 
-    # nodediscover list -f node,model,serial,mac|egrep 'J100GZG5|Node|----'
-      Node|      Model|     Serial|               Mac
-    ------|-----------|-----------|------------------
-     r4u29| 7Z01CTO1WW|   J100GZG5| 3c:e1:a1:c7:ea:79
+```bash
+# nodediscover list -f node,model,serial,mac|egrep 'J100GZG5|Node|----'
+  Node|      Model|     Serial|               Mac
+------|-----------|-----------|------------------
+ r4u29| 7Z01CTO1WW|   J100GZG5| 3c:e1:a1:c7:ea:79
+```
 
 
 
-    
+

--- a/docs/advanced_topics/confluentswitchdisco.md
+++ b/docs/advanced_topics/confluentswitchdisco.md
@@ -4,14 +4,14 @@ title: Using switch based discovery
 
 Confluent can identify unknown devices based on what network port they are connected to.
 
-# SNMP
+## SNMP
 For many industry switches, standard SNMP mibs are supported (QBRIDGE, BRIDGE, IF) to get the information.  If wanting to use SNMPv1/SNMPv2c, use the
 attribute 'secret.snmpcommunity' instead of `switchuser` and `switchpass` referenced below.
 
-# Cumulus
+## Cumulus
 For cumulus switches, install the affluent agent as documented in ['Using a Cumulus switch with confluent'](../miscellaneous/confluentcumulus.md)
 
-# Adding the ethernet switch
+## Adding the ethernet switch
 
 Adding an ethernet switch is done simply by adding the IP or a name that resolves to the switch:
 

--- a/docs/advanced_topics/confluentswitchdisco.md
+++ b/docs/advanced_topics/confluentswitchdisco.md
@@ -1,5 +1,7 @@
 ---
 title: Using switch based discovery
+tags:
+  - discovery
 ---
 
 Confluent can identify unknown devices based on what network port they are connected to.

--- a/docs/advanced_topics/confluenttoxcat.md
+++ b/docs/advanced_topics/confluenttoxcat.md
@@ -8,7 +8,7 @@ confluent does not require a dynamic range and does not require net-snmp-perl.
 Additionally, confluent supports standby power discovery in a number of scenarios,
 enabling management and console access prior to turning on the system.
 
-# Preparing for PXE mac collection
+## Preparing for PXE mac collection
 
 In order to direct confluent to retain PXE mac addresses, simply set the `net.bootable` attribute to 1 and ensure that `discovery.policy` includes PXE:
 
@@ -16,7 +16,7 @@ In order to direct confluent to retain PXE mac addresses, simply set the `net.bo
 # nodegroupattrib everything discovery.policy=permissive,pxe net.bootable=1
 ```
 
-# Perform normal confluent discovery
+## Perform normal confluent discovery
 
 Confluent discovery may be done against the BMC device or against PXE attempts. If using the network switch as a reference for discovery, be sure
 to use the dedicated management port switch and port for standby power discovery, and the network boot port switch and port if doing PXE. Detailed
@@ -26,7 +26,7 @@ procedures on a few strategies for discovery are:
 * [Discovering systems in enclosures](confluentenclosuredisco.md)
 * [Discovering systems manually](confluentnodeassign.md)
 
-# Populating xCAT with node information
+## Populating xCAT with node information
 
 Confluent has a command called `confluent2xcat` to export confluent data to xCAT. It can generate one of two files.
 

--- a/docs/advanced_topics/confluenttoxcat.md
+++ b/docs/advanced_topics/confluenttoxcat.md
@@ -12,7 +12,9 @@ enabling management and console access prior to turning on the system.
 
 In order to direct confluent to retain PXE mac addresses, simply set the `net.bootable` attribute to 1 and ensure that `discovery.policy` includes PXE:
 
-    # nodegroupattrib everything discovery.policy=permissive,pxe net.bootable=1
+```bash
+# nodegroupattrib everything discovery.policy=permissive,pxe net.bootable=1
+```
 
 # Perform normal confluent discovery
 
@@ -30,10 +32,14 @@ Confluent has a command called `confluent2xcat` to export confluent data to xCAT
 
 In order to generate a 'stanza' format file for mkdef (pulling in confluent group membership and other information):
 
-    # confluent2xcat d1-d8 -o nodes.stanza
+```bash
+# confluent2xcat d1-d8 -o nodes.stanza
+```
 
 In order to generate a CSV of node and mac addresses suitable for tabrestore mac:
 
-    # confluent2xcat d1-d8 -m mac.csv
+```bash
+# confluent2xcat d1-d8 -m mac.csv
+```
 
 

--- a/docs/advanced_topics/el7rste.md
+++ b/docs/advanced_topics/el7rste.md
@@ -2,7 +2,7 @@
 title: Using xCAT to install EL7 on Intel RSTe
 ---
 
-# Directing xCAT to install to the RSTe array
+## Directing xCAT to install to the RSTe array
 
 The disk to specify would be `/dev/md/Volume0_0`.  To do this in xCAT, create a file called  /install/custom/el7rste.partitions containing the following:
 
@@ -25,7 +25,7 @@ Modify the osimage to use this file, for example:
 
 Future nodeset commands will target the RSTe volume.
 
-# Adding support to 7.4 (not needed for 7.5 or newer)
+## Adding support to 7.4 (not needed for 7.5 or newer)
 
 
 EL 7.5 and newer include support, for 7.4 it is required to download the RSTe software from Lenovo [support site](https://datacentersupport.lenovo.com/us/en/products/SERVERS/THINKSYSTEM/SD530/7X21/downloads/DS504607)

--- a/docs/advanced_topics/el7rste.md
+++ b/docs/advanced_topics/el7rste.md
@@ -6,18 +6,22 @@ title: Using xCAT to install EL7 on Intel RSTe
 
 The disk to specify would be `/dev/md/Volume0_0`.  To do this in xCAT, create a file called  /install/custom/el7rste.partitions containing the following:
 
-    ignoredisk --only-use=/dev/md/Volume0_0
-    part /boot/efi --size 50 --ondisk /dev/md/Volume0_0 --fstype efi
-    part /boot --size 512 --fstype xfs --ondisk /dev/md/Volume0_0
-    part swap --recommended --ondisk /dev/md/Volume0_0
-    part pv.01 --size 1 --grow --ondisk /dev/md/Volume0_0
-    volgroup system pv.01
-    logvol / --vgname=system --name=root --size 1 --grow --fstype xfs
-    bootloader  --boot-drive=Volume0_0
+```bash
+ignoredisk --only-use=/dev/md/Volume0_0
+part /boot/efi --size 50 --ondisk /dev/md/Volume0_0 --fstype efi
+part /boot --size 512 --fstype xfs --ondisk /dev/md/Volume0_0
+part swap --recommended --ondisk /dev/md/Volume0_0
+part pv.01 --size 1 --grow --ondisk /dev/md/Volume0_0
+volgroup system pv.01
+logvol / --vgname=system --name=root --size 1 --grow --fstype xfs
+bootloader  --boot-drive=Volume0_0
+```
 
 Modify the osimage to use this file, for example:
 
-     chdef -t osimage centos7.5-x86_64-install-compute partitionfile=/install/custom/el7rste.partitions
+```bash
+ chdef -t osimage centos7.5-x86_64-install-compute partitionfile=/install/custom/el7rste.partitions
+```
 
 Future nodeset commands will target the RSTe volume.
 
@@ -28,14 +32,20 @@ EL 7.5 and newer include support, for 7.4 it is required to download the RSTe so
 
 Then, extract the archive to get the install iso:
 
-    $ tar xf intc-lnvgy_dd_iastor_rste5.3-693_linux_x86_64.tgz
+```bash
+$ tar xf intc-lnvgy_dd_iastor_rste5.3-693_linux_x86_64.tgz
+```
 
 Then extract updates.img from the iso.  You could loop mount or use isoinfo to extract:
 
-    $ isoinfo -i intc-lnvgy_dd_iastor_5.3-693_linux_x86_64/rste-5.3_rhel7.4.iso -R -x /updates.img > /install/rste.img
+```bash
+$ isoinfo -i intc-lnvgy_dd_iastor_5.3-693_linux_x86_64/rste-5.3_rhel7.4.iso -R -x /updates.img > /install/rste.img
+```
 
 Set bootparams.addkcmdline to pull in the given update:
 
-    $ nodegrpch rste bootparams.addkcmdline=" updates=http://<xcatmgt.name>/install/rste.img"
+```bash
+$ nodegrpch rste bootparams.addkcmdline=" updates=http://<xcatmgt.name>/install/rste.img"
+```
 
 From this point forward, any members of the rste group will pull in the RSTe software on install.

--- a/docs/advanced_topics/installxcat_rhel.md
+++ b/docs/advanced_topics/installxcat_rhel.md
@@ -4,27 +4,39 @@ title: xCAT Installation for Red Hat Enterprise Linux 7
 
 After adding the correct repository as indicated in the [download page](../downloads.md), you can install xCAT by running:
 
-    yum install xCAT
+```bash
+yum install xCAT
+```
 
 It is strongly recommended to also install lenovo-onecli:
 
-    yum install lenovo-onecli
+```bash
+yum install lenovo-onecli
+```
 
 The default assures ability to use a local SQLite database.  If you want to use PostgreSQL you will also need:
 
-    yum install perl-DBD-Pg
+```bash
+yum install perl-DBD-Pg
+```
 
 If you wish to use MySQL instead, then:
 
-    yum install perl-DBD-MySQL
+```bash
+yum install perl-DBD-MySQL
+```
 
 To verify that you have installed xCAT
 
-    service xcatd status
+```bash
+service xcatd status
+```
 
 At this point, source the script below for xCAT command line functionality or logout and log back in. 
 
-    source /etc/profile.d/xcat.sh
+```bash
+source /etc/profile.d/xcat.sh
+```
 
 For some notes on configuring certain Lenovo equipment in xCAT, see [xCAT configuration notes](xcatconfignotes.md)
 

--- a/docs/advanced_topics/installxcat_suse.md
+++ b/docs/advanced_topics/installxcat_suse.md
@@ -6,27 +6,39 @@ Note that for SUSE Linux Enterprise 15, the HA module is required to be availabl
 
 After adding the correct repository as indicated in the [download page](../downloads.md), you can install xCAT by running:
 
-    zypper install xCAT
+```bash
+zypper install xCAT
+```
 
 It is strongly recommended to also install lenovo-onecli:
 
-    zypper install lenovo-onecli
+```bash
+zypper install lenovo-onecli
+```
 
 The default assures ability to use a local SQLite database.  If you want to use PostgreSQL you will also need:
 
-    zypper install perl-DBD-Pg
+```bash
+zypper install perl-DBD-Pg
+```
 
 If you wish to use MySQL instead, then:
 
-    zypper install perl-DBD-MySQL
+```bash
+zypper install perl-DBD-MySQL
+```
 
 To verify that you have installed xCAT
 
-    service xcatd status
+```bash
+service xcatd status
+```
 
 At this point, source the script below for xCAT command line functionality or logout and log back in. 
 
-    source /etc/profile.d/xcat.sh
+```bash
+source /etc/profile.d/xcat.sh
+```
 
 For some notes on configuring certain Lenovo equipment in xCAT, see [xCAT configuration notes](xcatconfignotes.md)
 

--- a/docs/advanced_topics/installxcat_suse.md
+++ b/docs/advanced_topics/installxcat_suse.md
@@ -2,7 +2,8 @@
 title: xCAT Installation for SUSE Linux Enterprise
 ---
 
-Note that for SUSE Linux Enterprise 15, the HA module is required to be available for xCAT install to succeed.
+!!! note
+    For SUSE Linux Enterprise 15, the HA module is required to be available for xCAT install to succeed.
 
 After adding the correct repository as indicated in the [download page](../downloads.md), you can install xCAT by running:
 

--- a/docs/advanced_topics/remoteconfluent.md
+++ b/docs/advanced_topics/remoteconfluent.md
@@ -12,27 +12,35 @@ in conjunction with xCAT in a service node setup.
 First, on every confluent server you want to access, a user must be created, using the
 same procedure as creating a user for the Web API:
 
-    useradd demouser
-    passwd demouser
-    confetty create /users/demouser role=admin
+```bash
+useradd demouser
+passwd demouser
+confetty create /users/demouser role=admin
+```
 
 Additionally, a TLS certificate must be provided, with the private key in /etc/confluent/privkey.pem and
 the certificate in /etc/confluent/srvcert.pem.  You can generate such certificates using the collective command:
 
-    collective gencert
+```bash
+collective gencert
+```
 
 At this point, xCAT's rcons will take care of connecting to the correct server.  However, it will
 prompt for your confluent user and passphrase each time.  The user and password may alternatively
 be provided via environment variables:
 
-    CONFLUENT_USER=demouser
-    CONFLUENT_PASSPHRASE="password"
-    export CONFLUENT_USER CONFLUENT_PASSPHRASE
+```bash
+CONFLUENT_USER=demouser
+CONFLUENT_PASSPHRASE="password"
+export CONFLUENT_USER CONFLUENT_PASSPHRASE
+```
 
 Additionally, while rcons automatically connects to the relevant confluent server, other confluent commands
 currently do not get automatically routed.  If you want to run a confluent command such as nodepower explicitly
 against another host, this can be done by setting the CONFLUENT_HOST variable:
 
-    CONFLUENT_HOST=10.1.0.1
-    export CONFLUENT_HOST
+```bash
+CONFLUENT_HOST=10.1.0.1
+export CONFLUENT_HOST
+```
 

--- a/docs/advanced_topics/sles12rste.md
+++ b/docs/advanced_topics/sles12rste.md
@@ -6,28 +6,32 @@ xCAT does not currently consider the RSTe array as a default
 install target.  To override the behavior and direct the OS
 to be installed to RSTe, first create a file called /install/custom/sles12rste.partitions containing the following:
 
-    <drive>
-     <device>/dev/md/Volume0</device>
-     <partitions config:type="list">
-         <partition>
-             <filesystem config:type="symbol">vfat</filesystem>
-              <mount>/boot/efi</mount><size>128mb</size>
-          </partition>
+```bash
+<drive>
+ <device>/dev/md/Volume0</device>
+ <partitions config:type="list">
+     <partition>
+         <filesystem config:type="symbol">vfat</filesystem>
+          <mount>/boot/efi</mount><size>128mb</size>
+      </partition>
+      <partition>
+          <mount>swap</mount>
+          <size>auto</size>
+      </partition>
           <partition>
-              <mount>swap</mount>
-              <size>auto</size>
-          </partition>
-              <partition>
-               <mount>/</mount>
-               <size>auto</size>
-          </partition>
-     </partitions>
-     <initialize config:type="boolean">true</initialize>
-    </drive>
+           <mount>/</mount>
+           <size>auto</size>
+      </partition>
+ </partitions>
+ <initialize config:type="boolean">true</initialize>
+</drive>
+```
 
 With this in place, modify the osimage to use this partition plan:
 
-    chdef -t osimage sles12.3-x86_64-install-compute partitionfile=/install/custom/sles12rste.partitions 
+```bash
+chdef -t osimage sles12.3-x86_64-install-compute partitionfile=/install/custom/sles12rste.partitions 
+```
 
 From that point forward invocations of the nodeset command will target the RSTe volume.
 

--- a/docs/advanced_topics/switchtonginx.md
+++ b/docs/advanced_topics/switchtonginx.md
@@ -11,17 +11,23 @@ Modern confluent includes some configuration for both nginx and apache, but as p
 
 The procedure:
 
-    dnf install nginx
+```bash
+dnf install nginx
+```
 
 With nginx installed, examine the configuration.  For example, edit `/etc/nginx/nginx.conf` and uncomment the "Settings for a TLS enabled server" section.
 
 After enabling the nginx configuration:
 
-    osdeploy initialize -t
+```bash
+osdeploy initialize -t
+```
 
 The above will read the nginx configuration, detect where the TLS material should be, and generate it as appropriate.  Note if the configuration indicates directories that do not exist, you will have to `mkdir -p` yourself to ensure the directory exists for `osdeploy` to write to.  With this done:
 
-    systemctl disable httpd --now
-    systemctl enable nginx --now
+```bash
+systemctl disable httpd --now
+systemctl enable nginx --now
+```
 
 The system should now be running with nginx instead

--- a/docs/advanced_topics/xcataddingsnmp.md
+++ b/docs/advanced_topics/xcataddingsnmp.md
@@ -12,9 +12,11 @@ Installing net-snmp-perl will add SNMP support to xCAT. Note that every rpm begi
 
 If the most recent download is still old enough to create issues trying to apply updates from RedHat or CentOS, you may build your own packages instead of using packages from an archive:
 
-    $ git clone https://git.centos.org/rpms/net-snmp.git
-    $ cd net-snmp
-    $ git checkout c8
-    $ cp SOURCES/* ~/rpmbuild/SOURCES
-    $ rpmbuild -ba SPECS/net-snmp.spec --define 'netsnmp_check 0'  --undefine '_disable_source_fetch'
+```bash
+$ git clone https://git.centos.org/rpms/net-snmp.git
+$ cd net-snmp
+$ git checkout c8
+$ cp SOURCES/* ~/rpmbuild/SOURCES
+$ rpmbuild -ba SPECS/net-snmp.spec --define 'netsnmp_check 0'  --undefine '_disable_source_fetch'
+```
 

--- a/docs/advanced_topics/xcatstatelessimagesles152.md
+++ b/docs/advanced_topics/xcatstatelessimagesles152.md
@@ -6,10 +6,12 @@ During the process of creating an `xCAT stateless image` under `SLES 15.2`, the 
 
 Repetitive output such as the following would be seen:
 
-    Loading repository data...
-    Reading installed packages...
-    'aaa_base' not found in package names. Trying capabilities.
-    No provider of 'aaa_base' found.
+```bash
+Loading repository data...
+Reading installed packages...
+'aaa_base' not found in package names. Trying capabilities.
+No provider of 'aaa_base' found.
+```
 
 In the example where the SLES 15.2 distribution has been extracted (`via the xCAT copycds utility`) onto an xCAT management node in the `/install/sle15.2/x86_64` directory, `the workaround` for the above problem would be to `rename the file` `/install/sle15.2/x86_64/1/repodata`, such as to `/install/sle15.2/x86_64/1/repodata-ignore`.
 

--- a/docs/developer/api.md
+++ b/docs/developer/api.md
@@ -83,7 +83,7 @@ systems appear here automatically as they are found.
 
 ## **API Structure**
 
-The Confluent API structure is set up like a psuedo file system. Reading these paths
+The Confluent API structure is set up like a pseudo file system. Reading these paths
 will list the respective data. To update, the same path is given, along with the data to
 be used in the update, such as *{'state' : [newstate]}*. 
 
@@ -158,7 +158,7 @@ the default OS boot is not desired, but only for one boot.  Parameters are:
                with persistent set to True should reboot from network from that
                point on, rather than reverting to default boot order after next
                boot
-* **nextdevice** - The device/psuedo device to use in the next boot attempt.  This
+* **nextdevice** - The device/pseudo device to use in the next boot attempt.  This
                is a single device and not an order of devices.  The recognized
                devices are:
   * *default* - Use the usual boot sequence behavior without any overrides
@@ -275,9 +275,10 @@ this provides the following mechanisms:
 * **enabled** - Enable or disable NTP
 * **servers** - Collection of servers currently configured. Can create new or update existing
 
-Note that in confluent, efforts are made to correct timestamps with detectable
-systematic errors, so local time on the management controller may not necessarily
-impact accuracy of data such as event log timestamps.
+!!! note
+    In confluent, efforts are made to correct timestamps with detectable
+    systematic errors, so local time on the management controller may not necessarily
+    impact accuracy of data such as event log timestamps.
 
 #### **Managing alert destinations: /nodes/[nodename]/configuration/management_controller/alerts/destinations/**
 

--- a/docs/developer/api.md
+++ b/docs/developer/api.md
@@ -1,5 +1,7 @@
 ---
 title: Confluent API Documentation
+tags:
+  - api
 ---
 
 Confluent models functionality in a hierarchical structure.  It is a RESTful or

--- a/docs/developer/api.md
+++ b/docs/developer/api.md
@@ -17,9 +17,11 @@ By default, confluent API is only accessible locally over a unix domain socket.
 To enable a remote user for HTTP access, the quickest method is to use confetty
 to create a local account:
 
-    # useradd apiuser
-    # passwd apiuser
-    # confetty create /users/apiuser role=Administrator
+```bash
+# useradd apiuser
+# passwd apiuser
+# confetty create /users/apiuser role=Administrator
+```
 
 With the above example, using 'apiuser' and the entered password in the user/password
 prompt will provide access when accessing the management server by http://servername:4005/.
@@ -30,11 +32,15 @@ as a good reference to review accessing the API.  For example, reviewing
 the source code of 'nodepower' can be very informative.  In general, a
 python developer will want to start by importing the client library:
 
-	import confluent.client as client
+```bash
+import confluent.client as client
+```
 
 Next, you'll want to create a client session:
 
-	session = client.Command()
+```bash
+session = client.Command()
+```
 
 By default, this will reach out to the local instance.  If you want to reach
 out to a remote server, you may pass that as a string to the `Command()` call,

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -3,8 +3,7 @@
 Lenovo provides yum repositories of relevant software for managing HPC as well
 as scale out Linux installations in general.  This includes xCAT and confluent.
 
-Adding Repository for Red Hat Enterprise Linux / AlmaLinux / Rocky Linux
-============================
+## Adding Repository for Red Hat Enterprise Linux / AlmaLinux / Rocky Linux
 
 Select the repository appropriate for the major version.
 
@@ -28,8 +27,7 @@ rpm -ivh https://hpc.lenovo.com/yum/latest/el8/x86_64/lenovo-hpc-yum-1-1.x86_64.
 
 If using Red Hat, On a new Minimal Install without Red Hat Subscription Manager configured. You will need additional packages from the install media. Follow instuctions to add the install media as a repository on [https://access.redhat.com/solutions/1355683](https://access.redhat.com/solutions/1355683 "https://access.redhat.com/solutions/1355683"). 
 
-Adding Repository for Ubuntu Linux
-============================
+## Adding Repository for Ubuntu Linux
 
 Download our gpg key:
 
@@ -50,13 +48,15 @@ Signed-By: /etc/apt/trusted.gpg.d/confluent.gpg
 
 Then run `apt update` to pull the repository information.
 
-Adding Repository for SuSE Linux Enterprise 15
-============================
-    rpm --import https://hpc.lenovo.com/yum/latest/suse15/x86_64/lenovohpckey.pub
-    zypper install https://hpc.lenovo.com/yum/latest/suse15/x86_64/lenovo-hpc-zypper-1-1.x86_64.rpm
+## Adding Repository for SuSE Linux Enterprise 15
 
-Adding Local Repository
-============================    
+```bash
+rpm --import https://hpc.lenovo.com/yum/latest/suse15/x86_64/lenovohpckey.pub
+zypper install https://hpc.lenovo.com/yum/latest/suse15/x86_64/lenovo-hpc-zypper-1-1.x86_64.rpm
+```
+
+## Adding Local Repository
+
 If you cannot reach the repository from your target system, you can download the package from a system that can reach [https://hpc.lenovo.com/downloads/]( https://hpc.lenovo.com/downloads/ "https://hpc.lenovo.com/downloads/" ) and then transfer and install the repositories locally on your target system. 
 
 The files may be browsed at [https://hpc.lenovo.com/downloads/]( https://hpc.lenovo.com/downloads/ "https://hpc.lenovo.com/downloads/" ):
@@ -88,9 +88,8 @@ cd /mnt/local_repo/lenovo-hpc-suse15/
 ./mklocalrepo.sh
 ```
 
-Further information
-=======================
+## Further information
+
 See the [documentation](index.md) for information on how to install and configure software provided in these repositories.
 
 Sources are available at [https://hpc.lenovo.com/downloads/sources/](https://hpc.lenovo.com/downloads/sources/)
-    

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -10,16 +10,22 @@ Select the repository appropriate for the major version.
 
 For Red Hat Enterprise Linux 10:
 
-    rpm -ivh https://hpc.lenovo.com/yum/latest/el10/x86_64/lenovo-hpc-yum-1-1.x86_64.rpm
+```bash
+rpm -ivh https://hpc.lenovo.com/yum/latest/el10/x86_64/lenovo-hpc-yum-1-1.x86_64.rpm
+```
 
 For Red Hat Enterprise Linux 9:
 
-    rpm -ivh https://hpc.lenovo.com/yum/latest/el9/x86_64/lenovo-hpc-yum-1-1.x86_64.rpm
+```bash
+rpm -ivh https://hpc.lenovo.com/yum/latest/el9/x86_64/lenovo-hpc-yum-1-1.x86_64.rpm
+```
 
 For Red Hat Enterprise Linux 8:
 
-    rpm -ivh https://hpc.lenovo.com/yum/latest/el8/x86_64/lenovo-hpc-yum-1-1.x86_64.rpm
-    
+```bash
+rpm -ivh https://hpc.lenovo.com/yum/latest/el8/x86_64/lenovo-hpc-yum-1-1.x86_64.rpm
+```
+
 If using Red Hat, On a new Minimal Install without Red Hat Subscription Manager configured. You will need additional packages from the install media. Follow instuctions to add the install media as a repository on [https://access.redhat.com/solutions/1355683](https://access.redhat.com/solutions/1355683 "https://access.redhat.com/solutions/1355683"). 
 
 Adding Repository for Ubuntu Linux
@@ -27,16 +33,20 @@ Adding Repository for Ubuntu Linux
 
 Download our gpg key:
 
-    # wget -O /etc/apt/trusted.gpg.d/confluent.gpg https://hpc.lenovo.com/apt/latest/lenovo-hpc.key
+```bash
+# wget -O /etc/apt/trusted.gpg.d/confluent.gpg https://hpc.lenovo.com/apt/latest/lenovo-hpc.key
+```
 
 Create the following apt configuration (e.g. as a file like /etc/apt/sources.list.d/lenovo-hpc.sources) if running Ubuntu 24.04 (noble):
 
 
-    Types: deb
-    URIs: https://hpc.lenovo.com/apt/latest/noble
-    Suites: noble
-    Components: main
-    Signed-By: /etc/apt/trusted.gpg.d/confluent.gpg
+```bash
+Types: deb
+URIs: https://hpc.lenovo.com/apt/latest/noble
+Suites: noble
+Components: main
+Signed-By: /etc/apt/trusted.gpg.d/confluent.gpg
+```
 
 Then run `apt update` to pull the repository information.
 
@@ -51,31 +61,33 @@ If you cannot reach the repository from your target system, you can download the
 
 The files may be browsed at [https://hpc.lenovo.com/downloads/]( https://hpc.lenovo.com/downloads/ "https://hpc.lenovo.com/downloads/" ):
 
-    #On a system that can reach https://hpc.lenovo.com/downloads/
-    #Download the package for your specific OS version
-    wget https://hpc.lenovo.com/downloads/latest-el9.tar.xz
-    #or
-    wget https://hpc.lenovo.com/downloads/latest-el10.tar.xz
-    #or
-    wget https://hpc.lenovo.com/downloads/latest-el8.tar.xz
-    #or
-    wget https://hpc.lenovo.com/downloads/latest-suse15.tar.xz
-    
-    #On your local system 
-    #Create folder for the local repository
-    mkdir /mnt/local_repo
-    
-    #Extract the repository 
-    tar -xf latest-el8.tar.xz -C /mnt/local_repo
-    #or
-    tar -xf latest-suse15.tar.xz -C /mnt/local_repo
-    
-    #Create lenovo-hpc.repo to point to the local repository
-    cd /mnt/local_repo/lenovo-hpc-el8/
-    #or
-    cd /mnt/local_repo/lenovo-hpc-suse15/
-    ./mklocalrepo.sh
-    
+```bash
+#On a system that can reach https://hpc.lenovo.com/downloads/
+#Download the package for your specific OS version
+wget https://hpc.lenovo.com/downloads/latest-el9.tar.xz
+#or
+wget https://hpc.lenovo.com/downloads/latest-el10.tar.xz
+#or
+wget https://hpc.lenovo.com/downloads/latest-el8.tar.xz
+#or
+wget https://hpc.lenovo.com/downloads/latest-suse15.tar.xz
+
+#On your local system 
+#Create folder for the local repository
+mkdir /mnt/local_repo
+
+#Extract the repository 
+tar -xf latest-el8.tar.xz -C /mnt/local_repo
+#or
+tar -xf latest-suse15.tar.xz -C /mnt/local_repo
+
+#Create lenovo-hpc.repo to point to the local repository
+cd /mnt/local_repo/lenovo-hpc-el8/
+#or
+cd /mnt/local_repo/lenovo-hpc-suse15/
+./mklocalrepo.sh
+```
+
 Further information
 =======================
 See the [documentation](index.md) for information on how to install and configure software provided in these repositories.

--- a/docs/getting_started/configureconfluent.md
+++ b/docs/getting_started/configureconfluent.md
@@ -1,5 +1,7 @@
 ---
 title: Configuring confluent
+tags:
+  - installation
 ---
 
 ## When used in conjunction with xCAT

--- a/docs/getting_started/confluentgroups.md
+++ b/docs/getting_started/confluentgroups.md
@@ -6,7 +6,7 @@ In confluent, there is a concept of node groups to provide convenient shorthand 
 a way to group attributes together.  This may be ignored and everything be individually managed directly,
 but the groups may provide for easier configuration management at larger scale of components.
 
-# Use in noderanges
+## Use in noderanges
 
 Node groups can be used the same as nodes in [noderange syntax](../manuals/noderange.md).  
 
@@ -17,27 +17,28 @@ excluding `switches` and `pdus`, without having to continually update the `all` 
 nodegroupdefine all noderange=everything,-switches,-pdus
 ```
 
-Note that `noderange` groups do not contribute to providing attributes to the node attributes.
+!!! note
+    `noderange` groups do not contribute to providing attributes to the node attributes.
 
-# Attribute inheritence
+## Attribute inheritence
 
 Attributes on a group will flow into specific node attributes.  A node may inherit attributes from multiple groups at the same time.  If a node is in multiple groups, and more than one group offers an attribute value, the highest priority group overrides the lower priority group.  Priority proceeds from the first listed group to last group for highest to lower priority when looking at the `groups` attribute on a node.  Attributes defined on a node specifically will always supersede anything from groups.  A
 large number of attributes require individual values, but proceed in a predictable fashion.  These may be defined on a group level, leveraging [attribute expressions](../user_reference/attributeexpressions.md) to individualize the
 group setting accordingly.
 
-# Using `nodeattrib` versus `nodegroupattrib`
+## Using `nodeattrib` versus `nodegroupattrib`
 
 A point of confusion is using `nodeattrib [group] [attribute]=[value]` versus `nodegroupattrib [group] [attribute]=[value]`.
 The `nodeattrib [group]` command sets attributes individually on every *current* member of [group].  This means that the attribute will override anything from groups, even if there's a higher priority group.  It means that the attribute will not be set
 on future members of the group, as it wasn't targeted by nodeattrib.  The `nodegroupattrib` command specifically ensures the attribute is set on the group.  It will avoid overriding higher priority groups and it will be inherited as appropriate on any
 future nodes added to the group going forward.
 
-# The `everything` group
+## The `everything` group
 
 There is an implicit group called `everything`, intended to provide a shorthand in lieu of global settings.  Anything set
 on a node can be set on `everything`, and attributes set on `everything` will be inherited by all nodes, unless the specific attribute is superseded by a higher priority group or the node itself.
 
-# Bringing it together
+## Bringing it together
 
 Now a sample will be presented leveraging groups to define a representative configuration.
 

--- a/docs/getting_started/confluentquickstart_el8.md
+++ b/docs/getting_started/confluentquickstart_el8.md
@@ -7,7 +7,7 @@ multiple ways to do things. For example, this document is going to skip configur
 an external DHCP server, automatic configuration based on physical location, and other topics. See the more detailed
 documentation for more detail and alternative strategies for particular areas.
 
-# Installing confluent
+## Installing confluent
 
 To install confluent as well as optional requirements, after adding a yum repository according to [download page](../downloads.md):
 
@@ -20,7 +20,7 @@ To install confluent as well as optional requirements, after adding a yum reposi
 
 More details, including firewall rules and enabling GUI login may be found in the dedicated install page.
 
-# Specifying some global behavior
+## Specifying some global behavior
 
 In confluent, most all configuration is node oriented and can be derived from a group. A default group
 called 'everything` is automatically added to every node. It provides a method to indicate global settings.
@@ -54,13 +54,13 @@ everything: secret.hardwaremanagementpassword: ********
 everything: secret.hardwaremanagementuser: ********
 ```
 
-# Leave IPv6 enabled
+## Leave IPv6 enabled
 
 Even if you are not using it explicitly, IPv6 needs to be enabled on interfaces. Generally this is default, but if you have disabled IPv6 on an interface, then re-enable it.
 No address needs to be assigned explicitly, no DHCPv6 server is needed.  The only thing required is that deployment interfaces have an automatic IPv6 address beginning with
 fe80::
 
-# Defining nodes
+## Defining nodes
 
 
 Nodes may contain any number of attributes. In this document, everything is defined at the group level, so we only need define the names. Here we
@@ -71,7 +71,7 @@ will use a simple n[number] scheme, though any scheme may be used.
 ```
 
 
-# Establishing hardware management through confluent discovery
+## Establishing hardware management through confluent discovery
 
 It is possible to skip discovery and manually configure the xClarity Controllers and define them to confluent. On the other extreme, it is possible to configure
 fully automatic discovery based on physical location.
@@ -138,13 +138,14 @@ n3: on
 n4: off
 ```
 
-# Preparing for OS deployment
+## Preparing for OS deployment
 
 If desiring only to prepare for hardware management, then the guide has completed. However, confluent also optionally supports OS deployment.
 
-# Preparing name resolution
+## Preparing name resolution
 
-Note that no particular name resolution solution is required, but this document suggests a basic strategy if no strategy is already in place.
+!!! note
+    No particular name resolution solution is required, but this document suggests a basic strategy if no strategy is already in place.
 
 We start by building /etc/hosts. This may be done manually, or noderun can be used to quickly generate lines for /etc/hosts. First a dry run to make sure it looks correct:
 
@@ -171,7 +172,7 @@ Finally, to quickly have a dns server, installing and starting dnsmasq can make 
 
 Any time /etc/hosts is updated, restart dnsmasq to have it pick up changes.
 
-# Initializing confluent OS deployment.
+## Initializing confluent OS deployment.
 
 The osdeploy command has an initialize subcommand to help set up requirements for OS deployment. Here the `-i` flag is used
 to interactively prompt on the options that are available:
@@ -211,7 +212,7 @@ Updated: genesis-x86_64
 Site initramfs content packed successfully
 ```
 
-# Importing Install media
+## Importing Install media
 
 The iso of a supported OS may be imported by using the `osdeploy import` command, for example:
 
@@ -222,10 +223,11 @@ complete: 100.00%
 Deployment profile created: rhel-8.2-x86_64-default
 ```
 
-Note that a new directory exists in /var/lib/confluent/public/os/rhel-8.2-x86_64-default. This is intended to be freely editable for customization
-as desired.
+!!! note
+    A new directory exists in /var/lib/confluent/public/os/rhel-8.2-x86_64-default. This is intended to be freely editable for customization
+    as desired.
 
-# Deploying a node
+## Deploying a node
 
 To initiate network deployment of the profile above, the nodedeploy command may be used (TIP: the profile name like many other things may be tab completed when used interactively):
 

--- a/docs/getting_started/confluentquickstart_el8.md
+++ b/docs/getting_started/confluentquickstart_el8.md
@@ -1,5 +1,7 @@
 ---
 title: Confluent quickstart
+tags:
+  - deployment
 ---
 
 This document provides one example flow from installation to capable cluster. Confluent is very flexible and there are

--- a/docs/getting_started/installconfluent_rhel.md
+++ b/docs/getting_started/installconfluent_rhel.md
@@ -28,7 +28,7 @@ At this point, source the script below for confluent command line functionality 
 source /etc/profile.d/confluent_env.sh
 ```
 
-# Enabling http connectivity for OS Deployment, REST API usage, and the Web UI
+## Enabling http connectivity for OS Deployment, REST API usage, and the Web UI
 
 If you have SELinux enforcing, you need to allow httpd to make network
 connections:
@@ -87,7 +87,7 @@ systemctl enable httpd --now
 
 If wanting to use nginx instead of Apache, then see this [document](../advanced_topics/switchtonginx.md) for details.
 
-# Web UI Forwarding feature
+## Web UI Forwarding feature
 
 The WebUI offers dynamic port forwarding.  To enable this feature, ensure TCP ports starting from port 3900 through however many ports you anticipate concurrently using.
 Otherwise, you may opt to disable the firewall:
@@ -97,7 +97,7 @@ systemctl stop firewalld
 systemctl disable firewalld
 ```
 
-# Web UI Login
+## Web UI Login
 
 In terms of confluent itself, it is by default set up without any user access.  To enable a user that can ssh into your server to access the web interface:
 
@@ -118,7 +118,7 @@ https://[server]/lenovo-confluent/
 ```
 
 
-# Preparing for discovery if firewall enabled
+## Preparing for discovery if firewall enabled
 
 If wanting to use the confluent discovery capabilities and you have a firewall enabled, further firewall configuration
 is required. First, check /etc/firewalld/firewalld.conf and ensure that the FirewallBackend is set to iptables,
@@ -141,7 +141,7 @@ firewall-cmd --reload
 ```
 
 
-# Getting ready to use confluent
+## Getting ready to use confluent
  
 Proceed to [configuring confluent](configureconfluent.md) for information on
 adding groups and nodes.

--- a/docs/getting_started/installconfluent_rhel.md
+++ b/docs/getting_started/installconfluent_rhel.md
@@ -1,5 +1,7 @@
 ---
 title: Confluent Installation for Red Hat Enterprise Linux
+tags:
+  - installation
 ---
 
 Enterprise Linux 8.6, 9.0, or 10.0 and higher is required for installation.

--- a/docs/getting_started/installconfluent_suse.md
+++ b/docs/getting_started/installconfluent_suse.md
@@ -1,5 +1,7 @@
 ---
 title: Confluent Installation for SUSE Linux Enterprise
+tags:
+  - installation
 ---
 
 SuSE Linux Enterprise 15 SP4 or higher is currently required for installation.

--- a/docs/getting_started/installconfluent_ubuntu.md
+++ b/docs/getting_started/installconfluent_ubuntu.md
@@ -1,5 +1,7 @@
 ---
 title: Confluent Installation for Ubuntu
+tags:
+  - installation
 ---
 
 Ubuntu Linux 22.04 or 24.04 is supported for installation.

--- a/docs/miscellaneous/collective_arch.md
+++ b/docs/miscellaneous/collective_arch.md
@@ -4,7 +4,7 @@ title: Confluent collective architecture
 
 This document will describe the design of the confluent collective implementation.
 
-# Collective contrasted with 'Hierarchical' mode
+## Collective contrasted with 'Hierarchical' mode
 
 In xCAT, the design point was generally is 'head' system and some number of 'service nodes'. If desiring HA in the 'head' role, it was up
 to the user to provide an active-backup HA solution.  If the 'head' system is gone, this generally meant the 'service nodes' would no longer
@@ -15,7 +15,7 @@ it may still be deployed in a hierarchical manner where conventionally certain n
 and 'service nodes' are collective members that reside on the appropriate networks to manage/deploy a subset of systems.  The main apparent difference
 will be that service nodes no longer care about the 'head' nodes going offline compared to a similar xCAT configuration.
 
-# Example topologies
+## Example topologies
 
 As confluent does not have restrictions around the role of collective members, there is flexibility in how you may approach a
 collective.
@@ -42,7 +42,7 @@ Or it may be a headless segmented collective, where the 'head' role is omitted:
 
 Any other number of mix and match of the above strategies may be used in a collective.
 
-# Intra-collective trust
+## Intra-collective trust
 
 The invite token generated as part of the invite/join procedure is used as a shared secret to mutually attest to the in-use certificates
 for a join, and the persistent trust is managed through mutual TLS authentication. Every communication within a collective is protected
@@ -50,40 +50,40 @@ by the certificates that were in-use at the time of issuing the join with the co
 that issued the invitation is validating the client, the client is also using the invitation to authenticate the collective member, assuring
 both parties that both certificates are valid with no intermediaries.
 
-# Replicated data
+## Replicated data
 
 The node attribute database is inherently replicated internally by confluent by collective members. This contrasts to xCAT in
 that no external database is required, and replication of the database is handled implicitly by joining the collective.  At every
 point, every active collective member has a full copy of the node attribute database and persists it locally to /etc/confluent/cfg. When
 a collective member goes offline and later reconnects, the full node attribute database is replicated to the reconnecting member.
 
-# Quorum
+## Quorum
 
 Confluent collective is driven by a straightforward quorum scheme: if half or more collective members are unreachable, the collective
 locks down functionality. At this time this includes all collective members with no mechanism to indicate consideration of only a subset.
 
-# Shared storage consideration
+## Shared storage consideration
 
 While the node attribute database is replicated automatically among collective members, the /var/lib/confluent storage used by OS deployment must be
 synchronized or shared at the user's discretion.  There is no particular requirement placed on the mechanism beyond that it be consistent when used
 by the collective members, so a number of storage synchronization or remote/clustered filesystem approaches are acceptable. In contrast to xCAT, where /install
 was expected to be partially consistent, partially unique to the service node, confluent expects the entirety of the directory to be consistent.
 
-# Request routing
+## Request routing
 
 A request/command may be issued to any member of the collective and will be internally distributed as appropriate among collective members according
 to nodes' respective collective.manager.
 
-# Failover of collective manager
+## Failover of collective manager
 
 When a collective member goes offline, nodes currently managed as indicated by `collective.manager` can be automatically reassigned by setting `collective.managercandidates`.
 
-# Restricting OS deployment to select collective members
+## Restricting OS deployment to select collective members
 
 In addition to indicating candidates for automatic failover, collective.managercandidates also indicates collective members that are allowed to offer deployment services to
 the respective node.
 
-# Considerations for local services like DHCP/tftp
+## Considerations for local services like DHCP/tftp
 
 In xCAT, the head/service nodes required specific DHCP configuration and usually service node specific boot configuration files.  In confluent, there are no such
 requirements.  The DHCP activity may be delegated or static assignments are given from the confluent server direct from the replicated node attribute database.

--- a/docs/miscellaneous/collective_arch.md
+++ b/docs/miscellaneous/collective_arch.md
@@ -1,5 +1,7 @@
 ---
 title: Confluent collective architecture
+tags:
+  - collective
 ---
 
 This document will describe the design of the confluent collective implementation.

--- a/docs/miscellaneous/confignet.md
+++ b/docs/miscellaneous/confignet.md
@@ -1,5 +1,7 @@
 ---
 title: Confluent multi interface configuration
+tags:
+  - networking
 ---
 
 Confluent profiles initialized as of 3.3 or later contain the `confignet` network configuration facility. It is invoked

--- a/docs/miscellaneous/confignet.md
+++ b/docs/miscellaneous/confignet.md
@@ -5,19 +5,19 @@ title: Confluent multi interface configuration
 Confluent profiles initialized as of 3.3 or later contain the `confignet` network configuration facility. It is invoked
 in the default firstboot sections of scripted install profiles and onboot sections of diskless profiles.
 
-# Specifiying multiple network interface configuration
+## Specifiying multiple network interface configuration
 
 The `net.*` attributes may be qualified by name. For example, it's possible to specify `net.management.ipv4_address=172.16.0.{n1}/16` and `net.compute.ipv4_address=172.17.0.{n1}/16`.
 The name between `net` and the specific attribute is up to the user and has no particular meaning to confluent apart from the name being used to group settings together.
 
-# Configuring additional interfaces with autosense
+## Configuring additional interfaces with autosense
 
 If a confluent deployment server is configured for a given subnet, the deploying server will autosense the correct IP subnet and match the group automatically.
 ```
 net.deployment.ipv4_address=1.2.3.4/16
 ```
 
-# Configuring additional interfacces manually
+## Configuring additional interfacces manually
 
 If autosense is not feasible or not desired, specifiy `net.name.interface_names` to indicate the interface to use with this network configuration.  For example:
 ```
@@ -26,7 +26,7 @@ net.infiniband.ipv4_address=1.2.3.4/16
 ```
 
 
-# Configuring a network interface team
+## Configuring a network interface team
 
 confignet supports configuring teams by specifiying the team mode by, for example, `net.compute.team_mode=lacp`. If the team members are on the same subnet as a confluent deployment servers, the members
 may be autodetected. If the member interfaces do not share a subnet with a confluent server, then the names must be explicitly specified in `net.*.interface_names`, e.g. `ib0,ib1`. 
@@ -44,7 +44,7 @@ net.example.ipv4_address=4.3.2.1/16
 net.example.interface_names=eno1,eno2
 ```
 
-# Features not implemented
+## Features not implemented
 
 The current features are not currently implemented as of this writing:
 

--- a/docs/miscellaneous/confluentbackup.md
+++ b/docs/miscellaneous/confluentbackup.md
@@ -6,7 +6,7 @@ Confluent maintains its database in /etc/confluent/cfg
 
 For a plain text backup and restore capability, the `confluentdbutil` utility is provided.
 
-# Backing up the database
+## Backing up the database
 
 The recommended approach is to do at least one interactive backup:
 
@@ -36,7 +36,7 @@ collective.json  main.json
 This backup is a full backup, but lacks a keys.json file to decrypt the content, and thus
 cannot be restored by itself.  
 
-# Restoring from backup
+## Restoring from backup
 
 If following the example above, and desiring to restore from the '/tmp/unattended/' backup, first
 copy in a keys.json file from the interactive backup:
@@ -60,7 +60,7 @@ If running the restore as root, then you may need to change ownership back to co
 ```
 
 
-# Redacting configuration
+## Redacting configuration
 
 Additionally, `confluentdbutil dump -r` will generate a dump that redacts the
 potentially sensitive material, if wanting to share for diagnostic purposes.

--- a/docs/miscellaneous/confluentbackup.md
+++ b/docs/miscellaneous/confluentbackup.md
@@ -10,22 +10,28 @@ For a plain text backup and restore capability, the `confluentdbutil` utility is
 
 The recommended approach is to do at least one interactive backup:
 
-    # confluentdbutil -p BackupPassw0rd dump /tmp/backup/
+```bash
+# confluentdbutil -p BackupPassw0rd dump /tmp/backup/
+```
 
 This will encrypt the encryption keys used to protect passwords that may need
 to be retained using a password that will be required to restore. The backup
 consists of some .json files:
 
-    # ls /tmp/backup/
-    collective.json  keys.json  main.json
+```bash
+# ls /tmp/backup/
+collective.json  keys.json  main.json
+```
 
 As an interactive backup is incompatible with a regular backup scheme, once
 you have one backup as above with a password protected keys.json file, the -s
 option may be used to skip keys.json for an unattended backup:
 
-    # confluentdbutil -s dump /tmp/unattended/
-    # ls /tmp/unattended/
-    collective.json  main.json
+```bash
+# confluentdbutil -s dump /tmp/unattended/
+# ls /tmp/unattended/
+collective.json  main.json
+```
 
 This backup is a full backup, but lacks a keys.json file to decrypt the content, and thus
 cannot be restored by itself.  
@@ -35,17 +41,23 @@ cannot be restored by itself.
 If following the example above, and desiring to restore from the '/tmp/unattended/' backup, first
 copy in a keys.json file from the interactive backup:
 
-    # cp /tmp/backup/keys.json /tmp/unattended
+```bash
+# cp /tmp/backup/keys.json /tmp/unattended
+```
 
 This will turn the backup in /tmp/unattended into a password protected backup that can be restored.
 
 With this, /tmp/unattended may be restored:
 
-    # confluentdbutil -p BackupPassw0rd restore /tmp/unattended
+```bash
+# confluentdbutil -p BackupPassw0rd restore /tmp/unattended
+```
 
 If running the restore as root, then you may need to change ownership back to confluent user:
 
-    # chown confluent /etc/confluent/cfg/*
+```bash
+# chown confluent /etc/confluent/cfg/*
+```
 
 
 # Redacting configuration
@@ -53,7 +65,9 @@ If running the restore as root, then you may need to change ownership back to co
 Additionally, `confluentdbutil dump -r` will generate a dump that redacts the
 potentially sensitive material, if wanting to share for diagnostic purposes.
 
-    # confluentdbutil -r dump /tmp/redacted
+```bash
+# confluentdbutil -r dump /tmp/redacted
+```
 
 See confluentdbutil [man page](../manuals/confluentdbutil.md) for more detail.
 

--- a/docs/miscellaneous/confluentcumulus.md
+++ b/docs/miscellaneous/confluentcumulus.md
@@ -6,56 +6,66 @@ In order to use a Cumulus switch with confluent, it requires
 installation of the `affluent` agent.  Install the .deb file
 from /opt/confluent/share/affluent/ onto the switch:
 
-    # scp /opt/confluent/share/affluent/*.deb cumulus@r4c1:~
-    # ssh -t cumulus@r4c1 sudo apt install ~cumulus/affluent_*.deb
+```bash
+# scp /opt/confluent/share/affluent/*.deb cumulus@r4c1:~
+# ssh -t cumulus@r4c1 sudo apt install ~cumulus/affluent_*.deb
+```
 
 
 Note that if the installation occurred after confluent tried to interrogate the
 switch, you may need to restart confluent:
 
-    # systemctl restart confluent
+```bash
+# systemctl restart confluent
+```
 
 With that installation complete, the switch merely
 has to be added to confluent.  Use the resolvable hostname or ip address
 as the nodename(s):
 
-    # nodedefine r4c1 type=switch hardwaremanagement.method=affluent
+```bash
+# nodedefine r4c1 type=switch hardwaremanagement.method=affluent
+```
 
 If the user and password is not set by the group (e.g. everything), then set those attributes as well:
 
-    # nodeattrib r4c1 -p switchuser switchpass
+```bash
+# nodeattrib r4c1 -p switchuser switchpass
+```
 
 The user and password would be the same that you would use to ssh into the switch.
 
 With a managed switch, `nodehealth`, `nodesensors`, `nodefirmware`, and `nodeinventory` work:
 
-    # nodehealth r4c1
-    r4c1: critical (PSU1:status is all_not_ok, 1, 1, installed)
-    # nodesensors r4c1
-    r4c1: Fan Tray 3: 3863 RPM
-    r4c1: Fan Tray 2: 3977 RPM
-    r4c1: Fan Tray 1: 4204 RPM
-    r4c1: PSU2:
-    r4c1: PSU1: critical,status is all_not_ok, 1, 1, installed
-    r4c1: CPU board: 37.50000 °C
-    r4c1: Fan board: 33.00000 °C
-    r4c1: Ambient 2: 47.00000 °C
-    r4c1: Ambient 1: 36.50000 °C
-    r4c1: Networking ASIC Die Temp Sensor: 50.10000 °C
-    r4c1: Networking ASIC Die Temp Sensor: 51.30000 °C
-    r4c1: Networking ASIC Die Temp Sensor: 50.10000 °C
-    r4c1: Core 1: 29.00000 °C
-    r4c1: Core 0: 29.00000 °C
-    # nodeinventory r4c1
-    r4c1: System Manufacturer: Lenovo
-    r4c1: System Serial Number: NNNNNNNN
-    r4c1: System Product name: Lenovo ThinkSystem NE0152T RackSwitch
-    r4c1: System Model: 7Y81CTO1WW
-    r4c1: System Board manufacture date: 03/05/2019 13:33:34
-    r4c1: System Revision: 4
-    # nodefirmware r4c1 
-    r4c1: Cumulus Linux: 4.2.0
-    
+```bash
+# nodehealth r4c1
+r4c1: critical (PSU1:status is all_not_ok, 1, 1, installed)
+# nodesensors r4c1
+r4c1: Fan Tray 3: 3863 RPM
+r4c1: Fan Tray 2: 3977 RPM
+r4c1: Fan Tray 1: 4204 RPM
+r4c1: PSU2:
+r4c1: PSU1: critical,status is all_not_ok, 1, 1, installed
+r4c1: CPU board: 37.50000 °C
+r4c1: Fan board: 33.00000 °C
+r4c1: Ambient 2: 47.00000 °C
+r4c1: Ambient 1: 36.50000 °C
+r4c1: Networking ASIC Die Temp Sensor: 50.10000 °C
+r4c1: Networking ASIC Die Temp Sensor: 51.30000 °C
+r4c1: Networking ASIC Die Temp Sensor: 50.10000 °C
+r4c1: Core 1: 29.00000 °C
+r4c1: Core 0: 29.00000 °C
+# nodeinventory r4c1
+r4c1: System Manufacturer: Lenovo
+r4c1: System Serial Number: NNNNNNNN
+r4c1: System Product name: Lenovo ThinkSystem NE0152T RackSwitch
+r4c1: System Model: 7Y81CTO1WW
+r4c1: System Board manufacture date: 03/05/2019 13:33:34
+r4c1: System Revision: 4
+# nodefirmware r4c1 
+r4c1: Cumulus Linux: 4.2.0
+```
+
 Also, the /networking API and dependent discovery functionality is enabled.
     
     

--- a/docs/miscellaneous/confluentdhcp.md
+++ b/docs/miscellaneous/confluentdhcp.md
@@ -8,7 +8,7 @@ is not required, but also an independent DHCP server can be used on a network.
 For a standalone deployment without specific need for a dynamic pool, this doesn't require much consideration, the network will 'just work'.
 However, there are some considerations in various scenarios.
 
-# Working with an uncoordinated DHCP server offering dynamic addresses
+## Working with an uncoordinated DHCP server offering dynamic addresses
 
 The node attribute `net.ipv4_method` supports two possible modes for working with a DHCP server on the same network.
 
@@ -18,7 +18,7 @@ The node attribute `net.ipv4_method` supports two possible modes for working wit
 In a mostly static environment with a need for dynamic addressing, it is possible to use firmwaredhcp and setting dnsmasq or similar to serve up a dynamic range
 without having to coordinate the configuration.
 
-# Working with xCAT configured DHCP server
+## Working with xCAT configured DHCP server
 
 With xCAT, the biggest potential for conflict is the dynamic range, where xCAT will offer any network boot device a boot payload and potentially conflict.  There are a few strategies:
 
@@ -26,7 +26,7 @@ With xCAT, the biggest potential for conflict is the dynamic range, where xCAT w
  * Having devices only do HTTP boot.  xCAT does not support HTTP boot, so nodes doing HTTP boot will not receive offers from xCAT
  * Removing the boot payload from dynamic offers.  In dhcpd.conf, comment/remove the gpxe.no-pxedhcp option as well as filename entries to make the xCAT dhcp server no longer offer boot direction to unknown systems
 
-# How confluent works without a dynamic range
+## How confluent works without a dynamic range
 
 xCAT uses a dynamic range to boot linux on all unknown systems, and then in that linux environment work is done to try to discover the system.  In confluent, there are two discovery strategies:
 

--- a/docs/miscellaneous/confluentdhcp.md
+++ b/docs/miscellaneous/confluentdhcp.md
@@ -1,5 +1,7 @@
 ---
 title: Confluent and DHCP interaction
+tags:
+  - networking
 ---
 
 For confluent OS deployment, a specific design goal is improved interoperability with DHCP infrastructure. The result is that a DHCP server

--- a/docs/miscellaneous/confluentdiskless.md
+++ b/docs/miscellaneous/confluentdiskless.md
@@ -4,7 +4,7 @@ title: Using confluent diskless support
 
 Confluent offers the ability to create diskless images to boot operating systems. This facility is managed through the `imgutil` command.
 
-# Importing from installation media
+## Importing from installation media
 
 When going to build a diskless image, the default is to pull from the same repositories that the current operating system is using. However,
 it is possible to deploy from imported media.  If wanting to use this strategy, import the media as normal:
@@ -14,7 +14,7 @@ it is possible to deploy from imported media.  If wanting to use this strategy, 
     complete: 100.00%    
     Deployment profile created: alma-8.5-x86_64-default
 
-# Creating initial root filesystem tree
+## Creating initial root filesystem tree
 
 In confluent, the root filesystem can be built wherever you like and does not need to be retained after packing.  To build a new
 image from scratch:
@@ -24,7 +24,7 @@ image from scratch:
 The `-s` argument is optional, but when used should refer to a distribution in `osdeploy list`.  Tab completion also will work to help
 see the applicable options.  The /tmp/scratchdir directory tree is now ready for customization.
 
-# Customizing the root filesystem tree
+## Customizing the root filesystem tree
 
 `imgutil` provides an `exec` facility to help customize an root filesystem tree.  It starts the tree specified using container technologies (namespaces and chroot).
 It is possible to make a directory available from the build system into the exec environment with the -v argument.  For example, to have root's home directory available:
@@ -38,7 +38,7 @@ This can be used to execute arbitrary commands in a scripted fashion:
     # imgutil exec /tmp/scratchdir -- yum -y install perl
     # imgutil exec -v /root:- /tmp/scratchdir -- /root/MLNX_OFED_LINUX-5.4-3.1.0.0-rhel8.5-x86_64/mlnxofedinstall --distro rhel8.5
 
-# Packing the image for boot
+## Packing the image for boot
 
 Once the tree has been prepared, it needs to be packed to a profile name of your chosing, e.g.:
 
@@ -48,7 +48,7 @@ Once packed, the /tmp/scratchdir may be deleted if desired:
 
     # rm -rf /tmp/scratchdir
 
-# Unpacking image for modification
+## Unpacking image for modification
 
 If at any point a modification or update is required, `imgutil` can unpack a profile to a new location:
 
@@ -68,22 +68,23 @@ At which point modifications using imgutil exec or otherwise modifying the direc
 
     # imgutil pack -b alma-8.5-diskless /tmp/newscratchdir alma-8.5-disklesss-v2
 
-Note that '-b' will not function correctly if the distribution and nature of the
-profile do not match (e.g. using a different major version of linux, or trying to use diskful profile as a base for a diskless image).
+!!! note
+    '-b' will not function correctly if the distribution and nature of the
+    profile do not match (e.g. using a different major version of linux, or trying to use diskful profile as a base for a diskless image).
 
 This is a recommended method to preserve both copies until the new image is determined to be correctly working
 
-# Duplicating an image without repacking
+## Duplicating an image without repacking
 
 If wanting to copy a diskless profile for reasons that do not require repacking, then you must copy both /var/lib/confluent/private/os/<profilename> and /var/lib/confluent/public/os/<profilename>.
 The private portion usually contains an encryption key needed for the packed image to boot.
 
-# Login delays
+## Login delays
 
 If accounts suffer a one-time delay after initial login, this is likely due to systemd user slice failing to actually function.
 To mitigate, it is possible to modify thte TimeoutStopSec value in /usr/lib/systemd/system/user@.service to a smaller value, like 10s
 
-# SELinux labelling issues
+## SELinux labelling issues
 
 If errors arise during booting suggesting that, for example, sshd_config is not writable, it may be due to a mislabeled image. By default,
 the image should be labeled correctly, but if the scratch filesystem use did not support proper labelling, this can be a problem.
@@ -96,7 +97,7 @@ setfiles -r . /etc/selinux/targeted/contexts/files/file_contexts .
 imgputil pack /tmp/scratchdir -b image-name new-image-name
 ```
 
-# Moving an image between confluent servers
+## Moving an image between confluent servers
 
 A diskless image is comprised of private and public directories in /var/lib/confluent. To archive an image for moving between different confluent instances, tar will suffice:
 ```
@@ -113,12 +114,12 @@ On the server importing:
 
 This will preserve permissions and owner as well as leave symbolic links in a state to pick up the new confluent server addons and site specific content.
 
-# Using another host to build diskless images
+## Using another host to build diskless images
 
 If building an image is easier on another system, this is possible. For example, if the operating system mismatches or some software requires specific hardware to install. This is best accomplished
 by installing confluent on the 'build' system, but not bothering to define any nodes. This will include osdeploy initialize to have the profiles be complete, but the TLS and SSH data will not be carried over by the tar file and will take the site data from the target confluent instance. In this scenario, simply build
 as documented here and then use the procedure for moving an image between confluent servers to place the image into your deployment infrastructure.
 
-# SLES 15 diskless image product selection
+## SLES 15 diskless image product selection
 
 By default, building a SLES 15 diskless image will be setup as SuSE Linux Enterprise Server.  If the SuSE Linux Enterprise HPC product is desired, an additional package list file, including the SLE_HPC-release package should be created and specified with the "imgutil build -a" switch.

--- a/docs/miscellaneous/confluentdiskless.md
+++ b/docs/miscellaneous/confluentdiskless.md
@@ -1,5 +1,7 @@
 ---
 title: Using confluent diskless support
+tags:
+  - diskless
 ---
 
 Confluent offers the ability to create diskless images to boot operating systems. This facility is managed through the `imgutil` command.

--- a/docs/miscellaneous/confluentdiskless_arch.md
+++ b/docs/miscellaneous/confluentdiskless_arch.md
@@ -4,7 +4,7 @@ title: Confluent diskless architecture
 
 The confluent diskless implementation has a number of design points of interest compared to other diskless implementations or scripted install.
 
-# Build process
+## Build process
 
 In confluent, the `imgutil` command handles building, packing, unpacking, and modifying diskless images as well as cloning. Building and
 unpacking create a chroot-style directory. The `exec` subcommand allows spawning a specified directory in a new mount and process namespace with workable
@@ -13,32 +13,32 @@ rpm upgrade that would generate an updated initramfs for a disk-installed system
 the normal mkinitramfs/dracut/mkinitrd commands serve to generate the correct diskless filesystem.  Finally, packing an image produces a squashfs of the root
 filesystem, as well as extracting the appropriate kernel and initramfs.
 
-# Tethered diskless
+## Tethered diskless
 
 The default behavior is tethered diskless, where the diskless system detects paths to all relevant collective members and registers a filesystem
 to download from them in a multipath fashion on-demand. This avoids the up-front penalty in time and memory for downloading an entire diskless image,
 and avoids downloading unused portions of the image entirely. However, this precludes the ability of repacking in-place, and thus one must avoid
 packing over an in-use tethered diskless image.
 
-# Untethered diskless
+## Untethered diskless
 
 If wanting to uncouple from the filesystem, changing profile.yaml to untethered will alter the behavior. Rather than download on demand,
 the filesystem will be entirely downloaded to ram up-front. This will result in slower boot and larger memory consumption, but the memory
 consumption is still mitigated by leaving the filesystem compressed.
 
-# Writing to root filesystem in diskless mode
+## Writing to root filesystem in diskless mode
 
 The root filesystem is combined through overlay with a compressed ram xfs filesystem, with discard enabled. This means writes are compressed
 to mitigate memory cost and memory may be reclaimed through deleting written files. All data written in this manner will be lost on reboot.
 As of this writing, selective persistence of writable files to a remote filesystem is up to the user to implement.
 
-# Sensitive information in diskless images and encryption
+## Sensitive information in diskless images and encryption
 
 All effort is made to avoid writing sensitive information to the images, but rpms and exec may result in sensitive data in the filesystem
 beyond confluent's awareness.  Since the image is served over a public web server, it is therefore encrypted by default, with the private key
 stored in the 'private' directory alongside the 'public' directory.  This key is only provided through the confluent api
 
-# Node authentication using TPM2
+## Node authentication using TPM2
 
 No persistence to disk is possible to maintain node credentials such as ssh keys or the confluent node api key.  By default confluent diskless requires
 the use of a TPM2 to persist and protect the node api key.  During the diskless boot, an attempt is made to retrieve the Confluent Node API key from the TPM.

--- a/docs/miscellaneous/confluentdiskless_arch.md
+++ b/docs/miscellaneous/confluentdiskless_arch.md
@@ -1,5 +1,7 @@
 ---
 title: Confluent diskless architecture
+tags:
+  - diskless
 ---
 
 The confluent diskless implementation has a number of design points of interest compared to other diskless implementations or scripted install.

--- a/docs/miscellaneous/confluentpxedisco.md
+++ b/docs/miscellaneous/confluentpxedisco.md
@@ -1,5 +1,7 @@
 ---
 title: Using PXE driven discovery
+tags:
+  - discovery
 ---
 
 While the best experience is through discovering the xClarity Controller first and having full management

--- a/docs/miscellaneous/confluentpxedisco.md
+++ b/docs/miscellaneous/confluentpxedisco.md
@@ -11,7 +11,7 @@ prior to PXE booting, sometimes this is not feasible. Two such scenarios would b
 In such a scenario, doing discovery PXE first is a strategy to move forward.  Note that prior to confluent performing a PXE driven discovery, confluent must have
 [OS deployment capability initialized](../advanced_topics/confluentosdeploy.md)
 
-# Specifying a deployment target in advance
+## Specifying a deployment target in advance
 
 In confluent, the deployment may be directed before MAC addresses are yet known. For example to boot to Genesis (a provided diskless image for basic servicing and setup):
 
@@ -23,7 +23,7 @@ Or to boot into the installer on first viable boot attempt:
 
 Doing this in advance provides the earliest possible entry into a manageable operating system.
 
-# Specifying known mac address
+## Specifying known mac address
 
 It is supported to use a well known mac address without going through the discovery process.  Simply do:
 
@@ -31,7 +31,7 @@ It is supported to use a well known mac address without going through the discov
 
 To use it directly if mac address(es) are already known.
 
-# Manual discovery of unknown mac addresses
+## Manual discovery of unknown mac addresses
 
 The relevant system(s) must attempt a network boot. Generally new servers will tend to do this by default, so this is
 likely a matter of pressing the power button once.
@@ -49,7 +49,7 @@ An entry can be associated with a node in the same fashion as [manual discovery]
     Assigned: n1
 
 
-# Automatic discovery of mac addresses
+## Automatic discovery of mac addresses
 
 The same mechanisms that may be used for management controller and enclosure controller discovery in [using switch based discovery](../advanced_topics/confluentswitchdisco.md) may be used to help gather the PXE information automatically.  The difference being that `nodediscover rescan` will not work for PXE attempts, and confluent must simply wait for an attempt before it can proceed.
 
@@ -57,7 +57,7 @@ One example to designate the system cabled to a switch named `r4e1` on port `34`
 
     # nodedefine n1 discovery.policy=permissive,pxe net.switch=r4e1 net.switchport=34
 
-# Using PXE driven discovery to locally configure BMCs
+## Using PXE driven discovery to locally configure BMCs
 
 In this scenario it is generally desired to configure the BMC automatically, setting IP configuration and if applicable, moving it to the appropriate network port. The desired network port may be specified by the `hardwaremanagement.port` attribute. The most commonly desired values for PXE driven discovery would be `lom` to use the network port built into the system board of the device, or `ocp` to
 use an OCP card to provide BMC access.

--- a/docs/miscellaneous/confluentvxcat.md
+++ b/docs/miscellaneous/confluentvxcat.md
@@ -5,13 +5,13 @@ title: xCAT and confluent comparison
 As of confluent 3.0, the scope of Confluent has increased to cover much of xCAT functionality. There will
 remain some differences and some gaps.
 
-# Features not currently in confluent
+## Features not currently in confluent
 
 Confluent does not cover all functionality of xCAT. Some functions of xCAT that are currently not in confluent are:
 
 * Virtualization management
 
-# Interoperability
+## Interoperability
 
 xCAT generally is an all or nothing proposition. For full functionality, it must control DHCP, OS deployment, the BMC, and any data that is used in discovery can only
 be used to feed xCAT workflows.
@@ -19,7 +19,7 @@ be used to feed xCAT workflows.
 Confluent is designed for improved interoperability. It does not require control of services like DHCP, is less particular about DNS, and provides data more transparently
 to feed discovery data to alternative OS deployment software if desired rather than using the built in facilities.
 
-# Security
+## Security
 
 xCAT generally expects a trusted network and offers material unencrypted in various contexts. It does not support running under SELinux and it does not support SecureBoot.
 
@@ -35,7 +35,7 @@ The default configuration of confluent protects sensitive data. Even after optin
 * Non-recoverable hash of root password is no longer trivially retrieved from default kickstart files or images
 * Default SSH configuration is more hardened, no private key of any sort is sent across the network
 
-# Name resolution
+## Name resolution
 
 In xCAT, makedns is provided as an aid to generate ISC BIND configuration. However, it does not require this be used,
 and is content so long as forward and reverse lookup works exactly as expected.
@@ -45,7 +45,7 @@ if no other name resolution is otherwise in use. It is strongly recommended for 
 not required, and reverse lookup no longer has an impact on identifying nodes and will not cause problem identifying
 nodes if missing or not particularly configured.
 
-# DHCP
+## DHCP
 
 In xCAT, control of DHCP is mandatory for discovery and deployment functionality. No other DHCP server may be running
 on a network that xCAT needs to do discovery or deployment on.
@@ -54,7 +54,7 @@ In Confluent, DHCP is optional and even when present is not managed by Confluent
 any discovery. The default behavior is to use static IP address. It may also be configured to always defer IP configuration
 to an external DHCP server or to do so only for the firmware phase (PXE/HTTP boot) but use static for the OS.
 
-# Discovery
+## Discovery
 
 In xCAT, discovery requires that xCAT generate a dhcp configuration with a pool of dynamic addresses and boot into Linux on the
 nodes to begin the process.
@@ -64,7 +64,7 @@ on. If PXE driven discovery is required, the discovery occurs when firmware atte
 will be sent. A genesis environment is provided, though no longer required. `configbmc` may be used from either genesis `scripts/onboot.sh`
 or see `scripts/pre.custom` for an example to run it during application of an OS installation profile.
 
-# Deployment profiles
+## Deployment profiles
 
 In xCAT, deployment profiles  are comprised of content distributed
 across various directories combined and enhanced by data from various tables. This is powerful for having script content
@@ -78,7 +78,7 @@ no content will be replaced automatically on upgrade unless it is a symbolic lin
 Additionally, all nodes download the exact same set of boot configuration files and kickstart (or similar) files. All per-node
 specialization takes place on the target system rather than on the deployment server, as was the case in xCAT.
 
-# Postscripts
+## Postscripts
 
 In xCAT, postscripts are in /install/postscripts and referenced by either osimage or per node entries across the pertinent tables.
 
@@ -87,7 +87,7 @@ for the phase of boot. Most commonly, scripts/firstboot.custom, scripts/post.cus
 node sharing a common OS profile is not supported, and delegating that complexity to a facility such as salt or ansible is
 recommended.
 
-# SSH Infrastructure
+## SSH Infrastructure
 
 In xCAT, known_hosts was mitigated through disabling strict host key checking and copying down a common private host key to all nodes.
 This means that the host key was not well protected and also not unique (which mattered for some applications that presumed unique keys).
@@ -102,7 +102,7 @@ In Confluent, each collective member root public key is added to deployed author
 root's private key is never sent across the wire under any circumstance, instead the work to fix known_hosts across the board is leveraged to
 enable host-based authentication within a confluent cluster. This extends to both the root user and all other users on the systems.
 
-# Diskless
+## Diskless
 
 In xCAT, diskless images require a special script to run to generate the diskless and statelite initramfs.  Once ready, packimage tries to trim 'superfluous' content and creates a
 compressed image that is always downloaded and uncompressed into RAM. It is expected that the extracted form of the image persists in the `/install` directory.

--- a/docs/miscellaneous/containerized-confluent.md
+++ b/docs/miscellaneous/containerized-confluent.md
@@ -2,24 +2,20 @@
 title: Containerized confluent run 
 ---
 
-Synopsys
----------------
+## Synopsys
 
  Containerized confluent image with docker
 
-Solution
----------------
+## Solution
 
 To create a containerized confluent image with docker we need to edit the custom file "/confluent/container/Dockerfile 
 
-Constrains:
----------------
+## Constrains:
 
 Container must be run privileged.
 Container must be run with the ' --net = host' flag.
 
-Dockerfile customization
----------------
+## Dockerfile customization
 
 ```bash
 1  FROM almalinux:8    
@@ -54,8 +50,7 @@ These will add to bin and run the "runconfluent.sh" file that will install and r
 (default /confluent/container/runconfluent.sh)
 
 
-Reference 
----------------
+## Reference
 
 <https://github.com/lenovo/confluent/blob/master/container/Dockerfile>
 <https://github.com/lenovo/confluent/blob/master/container/runconfluent.sh>

--- a/docs/miscellaneous/containerized-confluent.md
+++ b/docs/miscellaneous/containerized-confluent.md
@@ -21,8 +21,10 @@ Container must be run with the ' --net = host' flag.
 Dockerfile customization
 ---------------
 
-    1  FROM almalinux:8    
- 
+```bash
+1  FROM almalinux:8    
+```
+
 Modify above line with the desired OS.
 
 Please note that Lenovo does NOT HOST any OS. The OS will be taken from a repository outside of Lenovo control. 
@@ -31,18 +33,22 @@ The next lines can be edited with the specific package manager commands.
 
 These will pull and install the dependencies needed to run confluent.
 
-    2   RUN   ["yum", "-y", "update"]
+```bash
+2   RUN   ["yum", "-y", "update"]
 
-    3   RUN   ["rpm", "-ivh", "https://hpc.lenovo.com/yum/latest/el8/x86_64/lenovo-hpc-yum-1-1.x86_64.rpm"]
+3   RUN   ["rpm", "-ivh", "https://hpc.lenovo.com/yum/latest/el8/x86_64/lenovo-hpc-yum-1-1.x86_64.rpm"]
 
-    4   RUN   ["yum", "-y", "install", "lenovo-confluent", "tftp-server", "openssh-clients", "openssl", "vim-enhanced", "iproute"]
+4   RUN   ["yum", "-y", "install", "lenovo-confluent", "tftp-server", "openssh-clients", "openssl", "vim-enhanced", "iproute"]
+```
 
 
 At the end we have the last two commands:
 
-    5   ADD runconfluent.sh /bin/
+```bash
+5   ADD runconfluent.sh /bin/
 
-    6   CMD ["/bin/bash", "/bin/runconfluent.sh"]
+6   CMD ["/bin/bash", "/bin/runconfluent.sh"]
+```
 
 These will add to bin and run the "runconfluent.sh" file that will install and run confluent.
 (default /confluent/container/runconfluent.sh)

--- a/docs/miscellaneous/doca3-0-install.md
+++ b/docs/miscellaneous/doca3-0-install.md
@@ -2,13 +2,13 @@
 title: DOCA 3.0 Installation/Upgrade on RHEL 9.5 and Ubuntu 24.04.2
 ---
 
-# DOCA 3.0 Installation/Upgrade on RHEL 9.5
+## DOCA 3.0 Installation/Upgrade on RHEL 9.5
 
 The following procedure is for installing or upgrading the NVIDIA DOCA stack (doca-ofed profile) on RHEL 9.5. 
 
  **NOTE** This is for a single-node install.  Scale with nodeshell and arguments to make these steps unattended as needed. 
 
-## Uninstall previous version of DOCA
+### Uninstall previous version of DOCA
  If upgrading from a previous version of DOCA, make sure to uninstall the previous version first, using the followoing steps (the following is an example for uninstalling DOCA 2.10):
 ```
 for f in $(rpm -qa | grep -i doca ) ; do yum -y remove $f; done
@@ -39,7 +39,7 @@ Additionally, running
 ```
 has been found to not work after running the "for f in $(rpm -qa | grep -i doca ) ; do yum -y remove $f; done" step to uninstall DOCA 2.10 as the ofed_uninstall.sh script then does not exist.  The steps above though do remove the DOCA package, so the ofed_uninstall.sh command can be omitted.
 
-## Register and subscribe a RHEL system to the Red Hat Customer Portal using Red Hat Subscription-Manager
+### Register and subscribe a RHEL system to the Red Hat Customer Portal using Red Hat Subscription-Manager
  This is required because some of the packages required are only available for registered systems. 
  ```
  subscription-manager register --username <username> --password <password> 
@@ -53,65 +53,65 @@ has been found to not work after running the "for f in $(rpm -qa | grep -i doca 
  ```
 
 
-## Enable update repos
+### Enable update repos
  These should be enabled already after the previous registration step, but this step will ensure this and is useful as a reference if these repos are disabled later.
  ```
  subscription-manager repos --enable=rhel-9-for-x86_64-baseos-rpms
  subscription-manager repos --enable=rhel-9-for-x86_64-appstream-rpms
  ```
 
-## Install newer kernel packages
+### Install newer kernel packages
  Note that these steps install a new version as opposed to replacing the older kernel version(s), so the system can be booted to the older kernel version(s) if needed.
  ```
  dnf install kernel kernel-core kernel-modules-core kernel-modules 
  ```
 
 
-## Install newer kernel devel packages
+### Install newer kernel devel packages
  Note that these steps install a new version as opposed to replacing the older kernel version(s), so the system can be booted to the older kernel version(s) if needed.
   ```
  dnf install kernel-devel kernel-devel-matched kernel-headers kernel-modules-extra
  ```
 
-## Update kernel tools and kernel abi stablelists
+### Update kernel tools and kernel abi stablelists
  Note that this still will update the existing kernel tools packages, as multiple versions of these kernel tools on the system as the same time.
  ```
  dnf install kernel-tools kernel-tools-libs kernel-abi-stablelists
  ```
 
   
-## Disable update repos
+### Disable update repos
  This step is optional, and is intended to keep all but the kernel packages at the base RHEL 9.5 levels.  This is mainly for reproducibility of environment, but leaving this step out to allow all of the OS packages to be at the latest level is equally valid.
  ```
  subscription-manager repos --disable=rhel-9-for-x86_64-appstream-rpms
  subscription-manager repos --disable=rhel-9-for-x86_64-baseos-rpms
  ```
 
-## Reboot the system using the newly installed kernel
+### Reboot the system using the newly installed kernel
  ```
  reboot
  ```
 
 
-## Install DOCA host local repo
+### Install DOCA host local repo
  ```
  rpm -ivh <path to local doca repo RPM>/doca-host-3.0.0-058000_25.04_rhel95.x86_64.rpm
  ```
 
 
-## Clean DNF/YUM cache 
+### Clean DNF/YUM cache 
  ```
  dnf makecache
  ```
 
 
-## Install DOCA extra package for building against errata kernel
+### Install DOCA extra package for building against errata kernel
  ```
  dnf install doca-extra
  ```
 
 
-## Patch the doca-kernel-support script 
+### Patch the doca-kernel-support script 
  This step is required since without it the mlnx-ofa_kernel-devel and mlnx-ofa_kernel-source packages will effectively be down-leveled to the ones not built for the errata kernel when installing the doca-ofed metapackage later.
  ```
  cd /opt/mellanox/doca/tools
@@ -140,64 +140,64 @@ EOF
  ```
 
 
-## Buid DOCA kernel packages errata kernel
+### Buid DOCA kernel packages errata kernel
  ```
  /opt/mellanox/doca/tools/doca-kernel-support
  ```
 
-## Install DOCA kernel packages repo built against errata kernel
+### Install DOCA kernel packages repo built against errata kernel
  **Note** The <temporary directory> name used in this step will be the one shown in the output of the previous step.
  ```
  rpm -ivh /tmp/<temporary directory>/doca-kernel-repo-25.04.0.6.1.0-1.kver.5.14.0.503.26.1.el9.5.x86.64.x86_64.rpm
  ```
 
 
-## Clean DNF/YUM cache
+### Clean DNF/YUM cache
  ```
  dnf makecache
  ```
 
 
-## Install the DOCA ofed-userspace meta package
+### Install the DOCA ofed-userspace meta package
  ```
  dnf install doca-ofed-userspace
  ```
 
-## Install the kmod-mlnx-ofa_kernel package before installing the doca-kernel metapackage.
+### Install the kmod-mlnx-ofa_kernel package before installing the doca-kernel metapackage.
  This step is required to avoid an issue where the kmod-srp package installs before the kmod-mlnx-ofa_kernel package is installed when the doca-kernel metapackage is installed, resulting in symbol error output from the install of the kmod-srp package.
  ```
  dnf install --disablerepo=doca  --setopt=install_deps=False kmod-mlnx-ofa_kernel
  ```
 
-## Install the DOCA doca-kernel meta package specifically from DOCA kernel packages repo built against errata kernel
+### Install the DOCA doca-kernel meta package specifically from DOCA kernel packages repo built against errata kernel
  ```
  dnf install --disablerepo=doca doca-kernel-5.14.0.503.26.1.el9.5.x86.64.noarch
  ```
 
-## Install the DOCA kmod-mlnx-nvme package specifically from DOCA kernel packages repo built against errata kernel
+### Install the DOCA kmod-mlnx-nvme package specifically from DOCA kernel packages repo built against errata kernel
  **Note** This step is optional and is only needed if using NVMeoF storage.
  ```
  dnf install --disablerepo=doca kmod-mlnx-nvme
  ```
 
-## Install the doca-ofed meta package
+### Install the doca-ofed meta package
  ```
  dnf install doca-ofed
  ```
 
 
-## Install the mlnx-fw-updater package
+### Install the mlnx-fw-updater package
  ```
  dnf install mlnx-fw-updater
  ```
 
-## Restart the system
+### Restart the system
 Note, restarting the system after the DOCA install or upgrade has been found to be more reliable then just restarting the openibd service (particularly on upgrade as restarting the openibd service has been found to cause system hangs in some cases).
  ```
  reboot
  ```
 
-## Check nvlsm
+### Check nvlsm
 For configurations where nvlsm was installed prior to upgrading DOCA, check to make sure it is still installed after the DOCA upgrade--in some cases the DOCA upgrade has been observed to remove nvlsm, in which case nvlsm will need to be re-installed after the DOCA upgrade.
 
 <br>
@@ -206,19 +206,19 @@ For configurations where nvlsm was installed prior to upgrading DOCA, check to m
 <br>
 
 
-# DOCA 3.0 Installation on Ubuntu 24.04.2
+## DOCA 3.0 Installation on Ubuntu 24.04.2
 
  The following procedure is for installing the NVIDIA DOCA stack (doca-ofed profile) on Ubuntu 24.04.2.
 
  **NOTE** This is for a single-node install. Scale with nodeshell.  Arguments to make these steps unattended have been included.
 
-## Install `make`
+### Install `make`
  An environment able to build kernel modules is necessary for installing DOCA with updated kernels on Ubuntu 24.04.  The DOCA packages don't include a dependency on `make`, though it is needed, so run the following to install `make`:
  ```
  DEBIAN_FRONTEND=noninteractive apt-get install -y make
  ```
 
-## Install the DOCA host repo package:
+### Install the DOCA host repo package:
  Install the DOCA host repo packaage:
  ```
  DEBIAN_FRONTEND=noninteractive dpkg -i <path to>/doca-host_3.0.0-058000-25.04-ubuntu2404_amd64.deb
@@ -229,19 +229,19 @@ For configurations where nvlsm was installed prior to upgrading DOCA, check to m
  DEBIAN_FRONTEND=noninteractive apt-get update -y
  ```
 
-## Install the doca-extra package
+### Install the doca-extra package
  There are two ways (mutually exclusive) of generating kernel module packages for the kernel modules included with DOCA 3.0.0 in Ubuntu for updated kernels.  One is to use the doca-extra package to build the kernel module packages explicitly against the updated kernel.  Another is to allow the dkms versions of the kernel module packages to be installed, in which case the kernel modules will implicitly be built against the update kernel.  The first of these options will be used here:
  ```
  DEBIAN_FRONTEND=noninteractive apt-get install -y doca-extra
  ```
 
-## Build the DOCA kernel module packages against the updated kernel:
+### Build the DOCA kernel module packages against the updated kernel:
  Run the following script provided by the doca-extra package to build the DOCA kernel module packages against the updated kernel:
  ```
  DEBIAN_FRONTEND=noninteractive /opt/mellanox/doca/tools/doca-kernel-support
  ```
 
-## Install the DOCA kernel repo generated by the doca-kernel-support script
+### Install the DOCA kernel repo generated by the doca-kernel-support script
  The doca-kernel-support script will generate a DOCA kernel repo package containing the DOCA kernel module packages built against the updated kernel.  This will be placed in `/tmp/DOCA.<suffix>`, where `<suffix>` is different each time the doca-kernel-support script is run.  If the doca-kernel-support script has been only run once, then using a wild card is sufficient to match this suffix and allows for scripting these install instructions without having to parse what `<suffix>` is in each case.  Note also that the particular updated kernel version will be in the DOCA kernel repo package name.  In this case kernel `6.8.0-63-generic` was used:
  ```
  DEBIAN_FRONTEND=noninteractive dpkg -i /tmp/DOCA.*/doca-kernel-repo-25.04-0.6.1.0-6.8.0.63.generic_25.04.0.6.1.0_amd64.deb
@@ -252,25 +252,25 @@ For configurations where nvlsm was installed prior to upgrading DOCA, check to m
  DEBIAN_FRONTEND=noninteractive apt-get update -y
  ```
 
-## Install the doca-ofed-userspace and doca-kernel-* metapackages
+### Install the doca-ofed-userspace and doca-kernel-* metapackages
  Install the doca-ofed-userspace and doca-kernel-* metapackages.  Installing the doca-kernel-* metapackage will install the DOCA kernel module packages built against the updated kernel in the previous steps.  Installing the doca-ofed-userspace metapackage will install most of the packages from the doca-ofed DOCA profile, with the exception of the DOCA kernel module dkms packages (which are unnecessary in this case since the DOCA kernel module packages were built in the previous steps, and conflict with the installation of the DOCA kernel module packages when they are installed), and the xpmem package.
  ```
  DEBIAN_FRONTEND=noninteractive apt-get install -y doca-ofed-userspace doca-kernel-6.8.0.63.generic
  ```
 
-## Install the mlnx-fw-updater package
+### Install the mlnx-fw-updater package
  Install the mlnx-fw-updater package.  Note that this package will not contain firmware for Lenovo-customized adapters--the firmware on those adapters will have to be updated separately.
  ```
  DEBIAN_FRONTEND=noninteractive apt-get install -y mlnx-fw-updater
  ```
 
-## Install xpmem
+### Install xpmem
  Install the xpmem package (this would have normally been installed when the doca-ofed metapackage was installed, but since the doca-ofed-userspace package is used in this case, the xpmem package has to be isntalled separately):
  ```
  DEBIAN_FRONTEND=noninteractive apt-get install -y xpmem
  ```
 
-## **OPTIONAL** Install mlnx-nvme-modules
+### **OPTIONAL** Install mlnx-nvme-modules
  If the using NVMeoF, install the mlnx-nvme-modules package:
  ```
  DEBIAN_FRONTEND=noninteractive apt-get install -y mlnx-nvme-modules

--- a/docs/miscellaneous/hpcxtroubleshooting.md
+++ b/docs/miscellaneous/hpcxtroubleshooting.md
@@ -2,7 +2,7 @@
 title: Troubleshooting issues with hpcx
 ---
 
-# libnuma Error
+## libnuma Error
 
 When using hpcx for MPI jobs on RHEL 9.5, the following error message may be displayed:
 
@@ -16,7 +16,7 @@ To keep this issue from happening, install the following package:
 numactl-devel-2.0.18-2.el9.x86_64
 ```
 
-# Multicast Errors
+## Multicast Errors
 
 The following errors may be reported when running an MPI job with hpcx:
 

--- a/docs/miscellaneous/manageconfluent.md
+++ b/docs/miscellaneous/manageconfluent.md
@@ -1,5 +1,7 @@
 ---
 title: Managing hardware using confluent
+tags:
+  - hardware
 ---
 
 As mentioned in the [configuring confluent](../getting_started/configureconfluent.md) section,

--- a/docs/miscellaneous/manageconfluent.md
+++ b/docs/miscellaneous/manageconfluent.md
@@ -25,149 +25,167 @@ Some examples are provided here, see the list of [man pages](../manuals/index.md
 
 Hard resetting nodes:
 
-    # nodepower d3-d6 boot
-    d3: on->reset
-    d5: on->reset
-    d6: on->reset
-    d4: on->reset
+```bash
+# nodepower d3-d6 boot
+d3: on->reset
+d5: on->reset
+d6: on->reset
+d4: on->reset
+```
 
 Forcing a boot into firmware configuration menu:
 
-    # nodeboot d3-d6 setup
-    d3: setup
-    d4: setup
-    d5: setup
-    d6: setup
-    d3: reset
-    d4: reset
-    d5: reset
-    d6: reset
+```bash
+# nodeboot d3-d6 setup
+d3: setup
+d4: setup
+d5: setup
+d6: setup
+d3: reset
+d4: reset
+d5: reset
+d6: reset
+```
 
 Accessing the console of a node:
 
-    # nodeconsole d4
+```bash
+# nodeconsole d4
+```
 
 Forcing a boot to network (e.g. to do a PXE or HTTP based deployment)
 
-    # nodeboot d3-d6 net
-    d3: network
-    d4: network
-    d5: network
-    d6: network
-    d3: reset
-    d4: reset
-    d5: reset
-    d6: reset
+```bash
+# nodeboot d3-d6 net
+d3: network
+d4: network
+d5: network
+d6: network
+d3: reset
+d4: reset
+d5: reset
+d6: reset
+```
 
 Examining firmware on a system:
 
-    # nodefirmware d5
-    d5: XCC: 4.00 (TEI3A4L 2020-07-13T23:58:08)
-    d5: XCC Backup: 1.20 (TEI316A 2017-10-30T00:00:00)
-    d5: XCC Trusted Image: TEI3A4L
-    d5: XCC Pending Update: 4.00 (TEI3A4L 2020-07-13T00:00:00)
-    d5: UEFI: 2.70 (TEE160L 2020-07-13T00:00:00)
-    d5: LXPM: 1.10 (PDL110O 2017-10-17T00:00:00)
-    d5: LXPM Windows Driver Bundle: 1.10 (PDL310P 2017-10-25T00:00:00)
-    d5: LXPM Linux Driver Bundle: 1.10 (PDL210O 2017-10-17T00:00:00)
-    d5: FPGA: 5.3.0
-    d5: Intel X722 LOM Combined Option ROM Image: 1.1767.0
-    d5: Intel X722 LOM Etrack ID: 80000D24
-    d5: ThinkSystem RAID 530-8i Dense MegaRAID Controller Firmware: 50.0.1-0378 (2017-08-01T00:00:00)
-    d5: ThinkSystem M.2 with Mirroring Enablement Kit Marvell Firmware: 2.3.10.1194 (2018-07-13T00:00:00)
-    d5: ThinkSystem M.2 with Mirroring Enablement Kit MRVL UEFI AHCI Driver and BIOS: 0.0.10.1024 (2017-10-25T00:00:00)
-    d5: Disk 0 ST1000NX0423: LE43
-    d5: Disk 1 ST1000NX0423: LE43
-    d5: Disk 2 ST1000NX0423: LE43
-    d5: Disk 3 ST1000NX0423: LE43
-    d5: Disk M.2-1 LITEON CV3-8D128: T87RA31 
-    d5: Disk M.2-2 LITEON CV3-8D128: T87RA31 
-    
+```bash
+# nodefirmware d5
+d5: XCC: 4.00 (TEI3A4L 2020-07-13T23:58:08)
+d5: XCC Backup: 1.20 (TEI316A 2017-10-30T00:00:00)
+d5: XCC Trusted Image: TEI3A4L
+d5: XCC Pending Update: 4.00 (TEI3A4L 2020-07-13T00:00:00)
+d5: UEFI: 2.70 (TEE160L 2020-07-13T00:00:00)
+d5: LXPM: 1.10 (PDL110O 2017-10-17T00:00:00)
+d5: LXPM Windows Driver Bundle: 1.10 (PDL310P 2017-10-25T00:00:00)
+d5: LXPM Linux Driver Bundle: 1.10 (PDL210O 2017-10-17T00:00:00)
+d5: FPGA: 5.3.0
+d5: Intel X722 LOM Combined Option ROM Image: 1.1767.0
+d5: Intel X722 LOM Etrack ID: 80000D24
+d5: ThinkSystem RAID 530-8i Dense MegaRAID Controller Firmware: 50.0.1-0378 (2017-08-01T00:00:00)
+d5: ThinkSystem M.2 with Mirroring Enablement Kit Marvell Firmware: 2.3.10.1194 (2018-07-13T00:00:00)
+d5: ThinkSystem M.2 with Mirroring Enablement Kit MRVL UEFI AHCI Driver and BIOS: 0.0.10.1024 (2017-10-25T00:00:00)
+d5: Disk 0 ST1000NX0423: LE43
+d5: Disk 1 ST1000NX0423: LE43
+d5: Disk 2 ST1000NX0423: LE43
+d5: Disk 3 ST1000NX0423: LE43
+d5: Disk M.2-1 LITEON CV3-8D128: T87RA31 
+d5: Disk M.2-2 LITEON CV3-8D128: T87RA31 
+```
+
 Applying a single XCC update across nodes d4,d5, and d6
 
-    # nodefirmware d4-d6 update lnvgy_fw_xcc_tei3a4l-4.00_anyos_noarch.uxz 
-    d4:upload:   5%       d5:upload:   5%       d6:upload:   6%       
-    ...
-    # nodebmcreset d4-d6
-    d4: BMC Reset Successful
-    d6: BMC Reset Successful
-    d5: BMC Reset Successful
+```bash
+# nodefirmware d4-d6 update lnvgy_fw_xcc_tei3a4l-4.00_anyos_noarch.uxz 
+d4:upload:   5%       d5:upload:   5%       d6:upload:   6%       
+...
+# nodebmcreset d4-d6
+d4: BMC Reset Successful
+d6: BMC Reset Successful
+d5: BMC Reset Successful
+```
 
 Checking firmware of XCC and using collate to check consistency:
 
-    # nodefirmware d3-d6 xcc |collate
-    ====================================
-    d4,d5,d6
-    ====================================
-    XCC: 4.00 (TEI3A4L 2020-07-13T23:58:08)
-    
-    ====================================
-    d3
-    ====================================
-    XCC: 4.00 (TEI3A3L 2020-07-10T06:43:45)
-    
+```bash
+# nodefirmware d3-d6 xcc |collate
+====================================
+d4,d5,d6
+====================================
+XCC: 4.00 (TEI3A4L 2020-07-13T23:58:08)
+
+====================================
+d3
+====================================
+XCC: 4.00 (TEI3A3L 2020-07-10T06:43:45)
+```
+
 Using nodeconfig to view uefi settings and collate -d to find deviations:
 
-    # nodeconfig d3-d6 processors | grep -v Processors.Processors13to16coresactive | collate -d
-    ====================================
-    d3,d5,d6
-    ====================================
-    Processors.TurboMode: Enable
-    Processors.CPUPstateControl: Autonomous
-    Processors.CStates: Autonomous
-    Processors.C1EnhancedMode: Enable
-    Processors.HyperThreading: Enable
-    Processors.TrustedExecutionTechnology: Disable
-    Processors.IntelVirtualizationTechnology: Enable
-    Processors.HardwarePrefetcher: Enable
-    Processors.AdjacentCachePrefetch: Enable
-    Processors.DCUStreamerPrefetcher: Enable
-    Processors.DCUIPPrefetcher: Enable
-    Processors.DCA: Enable
-    Processors.EnergyEfficientTurbo: Enable
-    Processors.UncoreFrequencyScaling: Enable
-    Processors.MONITORMWAIT: Enable
-    Processors.SnoopResponseHoldOff: 9
-    Processors.UPIGateDisable: Enable
-    Processors.UPILinkDisable: Enable All Links
-    Processors.SNC: Disable
-    Processors.SnoopPreference: Home Snoop Plus
-    Processors.UPIPrefetcher: Enable
-    Processors.Autocstatemapping: Legacy
-    Processors.StaleAtoS: Auto
-    Processors.LLCdeadlinealloc: Enable
-    Processors.AesEnable: Enable
-    Processors.IrqThreshold: Auto
-    Processors.LLCPrefetch: Disable
-    Processors.PackageCstate: Enable
-    Processors.L2RFOPrefetchDisable: Auto
-    Processors.PECIIsTrusted: Enable
-    Processors.UncoreFrequencyLimit: 3F
-    Processors.PL2: 1.2
-    Processors.CoresinCPUPackage: All
-    Processors.MaxPState: P0
-    Processors.DisableProcessor: None
-    Processors.UPILinkFrequency: Max Performance
-    Processors.CPUFrequencyLimits: Full turbo uplift
-    Processors.CRCMode: Auto
-    Processors.L1: Enable
-    Processors.L0p: Enable
-    Processors.Processors1to2coresactive:
-    Processors.Processors3to4coresactive:
-    Processors.Processors5to8coresactive:
-    Processors.Processors9to12coresactive:
-    
-    ====================================
-    d4
-    ====================================
-    @@
-      Processors.TurboMode: Enable
-    - Processors.CPUPstateControl: Autonomous
-    + Processors.CPUPstateControl: Cooperative
-      Processors.CStates: Autonomous
-      Processors.C1EnhancedMode: Enable
-        
+```bash
+# nodeconfig d3-d6 processors | grep -v Processors.Processors13to16coresactive | collate -d
+====================================
+d3,d5,d6
+====================================
+Processors.TurboMode: Enable
+Processors.CPUPstateControl: Autonomous
+Processors.CStates: Autonomous
+Processors.C1EnhancedMode: Enable
+Processors.HyperThreading: Enable
+Processors.TrustedExecutionTechnology: Disable
+Processors.IntelVirtualizationTechnology: Enable
+Processors.HardwarePrefetcher: Enable
+Processors.AdjacentCachePrefetch: Enable
+Processors.DCUStreamerPrefetcher: Enable
+Processors.DCUIPPrefetcher: Enable
+Processors.DCA: Enable
+Processors.EnergyEfficientTurbo: Enable
+Processors.UncoreFrequencyScaling: Enable
+Processors.MONITORMWAIT: Enable
+Processors.SnoopResponseHoldOff: 9
+Processors.UPIGateDisable: Enable
+Processors.UPILinkDisable: Enable All Links
+Processors.SNC: Disable
+Processors.SnoopPreference: Home Snoop Plus
+Processors.UPIPrefetcher: Enable
+Processors.Autocstatemapping: Legacy
+Processors.StaleAtoS: Auto
+Processors.LLCdeadlinealloc: Enable
+Processors.AesEnable: Enable
+Processors.IrqThreshold: Auto
+Processors.LLCPrefetch: Disable
+Processors.PackageCstate: Enable
+Processors.L2RFOPrefetchDisable: Auto
+Processors.PECIIsTrusted: Enable
+Processors.UncoreFrequencyLimit: 3F
+Processors.PL2: 1.2
+Processors.CoresinCPUPackage: All
+Processors.MaxPState: P0
+Processors.DisableProcessor: None
+Processors.UPILinkFrequency: Max Performance
+Processors.CPUFrequencyLimits: Full turbo uplift
+Processors.CRCMode: Auto
+Processors.L1: Enable
+Processors.L0p: Enable
+Processors.Processors1to2coresactive:
+Processors.Processors3to4coresactive:
+Processors.Processors5to8coresactive:
+Processors.Processors9to12coresactive:
+
+====================================
+d4
+====================================
+@@
+  Processors.TurboMode: Enable
+- Processors.CPUPstateControl: Autonomous
++ Processors.CPUPstateControl: Cooperative
+  Processors.CStates: Autonomous
+  Processors.C1EnhancedMode: Enable
+```
+
 Using nodeconfig to change the configuration:
 
-    # nodeconfig d4 set Processors.CPUPstateControl=auto
+```bash
+# nodeconfig d4 set Processors.CPUPstateControl=auto
+```
 

--- a/docs/miscellaneous/nokia-confignotes.md
+++ b/docs/miscellaneous/nokia-confignotes.md
@@ -42,170 +42,181 @@ running SR Linux 25.10.1.
 
  Note, using the subinterface name corresponding to the VLAN with which it would be associated isn't necessary, but is used as a useful convention in the example below.
 
-    set / interface ethernet-1/1 admin-state enable
-    set / interface ethernet-1/1 vlan-tagging true
-    set / interface ethernet-1/1 subinterface 101 type bridged
-    set / interface ethernet-1/1 subinterface 101 admin-state enable
-    set / interface ethernet-1/1 subinterface 101 vlan encap untagged
-    set / interface ethernet-1/2 admin-state enable
-    set / interface ethernet-1/2 vlan-tagging true
-    set / interface ethernet-1/2 subinterface 102 type bridged
-    set / interface ethernet-1/2 subinterface 102 admin-state enable
-    set / interface ethernet-1/2 subinterface 102 vlan encap untagged
-    set / interface ethernet-1/3 admin-state enable
-    set / interface ethernet-1/3 vlan-tagging true
-    set / interface ethernet-1/3 subinterface 101 type bridged
-    set / interface ethernet-1/3 subinterface 101 admin-state enable
-    set / interface ethernet-1/3 subinterface 101 vlan encap untagged
-    set / interface ethernet-1/3 subinterface 103 type bridged
-    set / interface ethernet-1/3 subinterface 103 admin-state enable
-    set / interface ethernet-1/3 subinterface 103 vlan encap single-tagged vlan-id 103
-    set / interface ethernet-1/3 subinterface 109 type bridged
-    set / interface ethernet-1/3 subinterface 109 admin-state enable
-    set / interface ethernet-1/3 subinterface 109 vlan encap single-tagged vlan-id 109
-    set / interface ethernet-1/4 admin-state enable
-    set / interface ethernet-1/4 vlan-tagging true
-    set / interface ethernet-1/4 subinterface 102 type bridged
-    set / interface ethernet-1/4 subinterface 102 admin-state enable
-    set / interface ethernet-1/4 subinterface 102 vlan encap untagged
-    set / interface ethernet-1/4 subinterface 103 type bridged
-    set / interface ethernet-1/4 subinterface 103 admin-state enable
-    set / interface ethernet-1/4 subinterface 103 vlan encap single-tagged vlan-id 103
-    set / interface ethernet-1/4 subinterface 109 type bridged
-    set / interface ethernet-1/4 subinterface 109 admin-state enable
-    set / interface ethernet-1/4 subinterface 109 vlan encap single-tagged vlan-id 109
-    set / interface ethernet-1/5 admin-state enable
-    set / interface ethernet-1/5 vlan-tagging true
-    set / interface ethernet-1/5 subinterface 101 type bridged
-    set / interface ethernet-1/5 subinterface 101 admin-state enable
-    set / interface ethernet-1/5 subinterface 101 vlan encap single-tagged vlan-id 101
-    set / interface ethernet-1/5 subinterface 102 type bridged
-    set / interface ethernet-1/5 subinterface 102 admin-state enable
-    set / interface ethernet-1/5 subinterface 102 vlan encap single-tagged vlan-id 102
-    set / interface ethernet-1/5 subinterface 103 type bridged
-    set / interface ethernet-1/5 subinterface 103 admin-state enable
-    set / interface ethernet-1/5 subinterface 103 vlan encap single-tagged vlan-id 103
-    set / interface ethernet-1/5 subinterface 109 type bridged
-    set / interface ethernet-1/5 subinterface 109 admin-state enable
-    set / interface ethernet-1/5 subinterface 109 vlan encap single-tagged vlan-id 109
-    set / interface ethernet-1/6 admin-state enable
-    set / interface ethernet-1/6 vlan-tagging true
-    set / interface ethernet-1/6 subinterface 101 type bridged
-    set / interface ethernet-1/6 subinterface 101 admin-state enable
-    set / interface ethernet-1/6 subinterface 101 vlan encap single-tagged vlan-id 101
-    set / interface ethernet-1/6 subinterface 102 type bridged
-    set / interface ethernet-1/6 subinterface 102 admin-state enable
-    set / interface ethernet-1/6 subinterface 102 vlan encap single-tagged vlan-id 102
-    set / interface ethernet-1/6 subinterface 103 type bridged
-    set / interface ethernet-1/6 subinterface 103 admin-state enable
-    set / interface ethernet-1/6 subinterface 103 vlan encap single-tagged vlan-id 103
-    set / interface ethernet-1/6 subinterface 109 type bridged
-    set / interface ethernet-1/6 subinterface 109 admin-state enable
-    set / interface ethernet-1/6 subinterface 109 vlan encap single-tagged vlan-id 109
-    set / network-instance bridge-vlan101 type mac-vrf
-    set / network-instance bridge-vlan101 admin-state enable
-    set / network-instance bridge-vlan101 interface ethernet-1/1.101
-    set / network-instance bridge-vlan101 interface ethernet-1/3.101
-    set / network-instance bridge-vlan101 interface ethernet-1/5.101
-    set / network-instance bridge-vlan101 interface ethernet-1/6.101
-    set / network-instance bridge-vlan102 type mac-vrf
-    set / network-instance bridge-vlan102 admin-state enable
-    set / network-instance bridge-vlan102 interface ethernet-1/2.102
-    set / network-instance bridge-vlan102 interface ethernet-1/4.102
-    set / network-instance bridge-vlan102 interface ethernet-1/5.102
-    set / network-instance bridge-vlan102 interface ethernet-1/6.102
-    set / network-instance bridge-vlan103 type mac-vrf
-    set / network-instance bridge-vlan103 admin-state enable
-    set / network-instance bridge-vlan103 interface ethernet-1/3.103
-    set / network-instance bridge-vlan103 interface ethernet-1/4.103
-    set / network-instance bridge-vlan103 interface ethernet-1/5.103
-    set / network-instance bridge-vlan103 interface ethernet-1/6.103
-    set / network-instance bridge-vlan109 type mac-vrf
-    set / network-instance bridge-vlan109 admin-state enable
-    set / network-instance bridge-vlan109 interface ethernet-1/3.109
-    set / network-instance bridge-vlan109 interface ethernet-1/4.109
-    set / network-instance bridge-vlan109 interface ethernet-1/5.109
-    set / network-instance bridge-vlan109 interface ethernet-1/6.109
+```bash
+set / interface ethernet-1/1 admin-state enable
+set / interface ethernet-1/1 vlan-tagging true
+set / interface ethernet-1/1 subinterface 101 type bridged
+set / interface ethernet-1/1 subinterface 101 admin-state enable
+set / interface ethernet-1/1 subinterface 101 vlan encap untagged
+set / interface ethernet-1/2 admin-state enable
+set / interface ethernet-1/2 vlan-tagging true
+set / interface ethernet-1/2 subinterface 102 type bridged
+set / interface ethernet-1/2 subinterface 102 admin-state enable
+set / interface ethernet-1/2 subinterface 102 vlan encap untagged
+set / interface ethernet-1/3 admin-state enable
+set / interface ethernet-1/3 vlan-tagging true
+set / interface ethernet-1/3 subinterface 101 type bridged
+set / interface ethernet-1/3 subinterface 101 admin-state enable
+set / interface ethernet-1/3 subinterface 101 vlan encap untagged
+set / interface ethernet-1/3 subinterface 103 type bridged
+set / interface ethernet-1/3 subinterface 103 admin-state enable
+set / interface ethernet-1/3 subinterface 103 vlan encap single-tagged vlan-id 103
+set / interface ethernet-1/3 subinterface 109 type bridged
+set / interface ethernet-1/3 subinterface 109 admin-state enable
+set / interface ethernet-1/3 subinterface 109 vlan encap single-tagged vlan-id 109
+set / interface ethernet-1/4 admin-state enable
+set / interface ethernet-1/4 vlan-tagging true
+set / interface ethernet-1/4 subinterface 102 type bridged
+set / interface ethernet-1/4 subinterface 102 admin-state enable
+set / interface ethernet-1/4 subinterface 102 vlan encap untagged
+set / interface ethernet-1/4 subinterface 103 type bridged
+set / interface ethernet-1/4 subinterface 103 admin-state enable
+set / interface ethernet-1/4 subinterface 103 vlan encap single-tagged vlan-id 103
+set / interface ethernet-1/4 subinterface 109 type bridged
+set / interface ethernet-1/4 subinterface 109 admin-state enable
+set / interface ethernet-1/4 subinterface 109 vlan encap single-tagged vlan-id 109
+set / interface ethernet-1/5 admin-state enable
+set / interface ethernet-1/5 vlan-tagging true
+set / interface ethernet-1/5 subinterface 101 type bridged
+set / interface ethernet-1/5 subinterface 101 admin-state enable
+set / interface ethernet-1/5 subinterface 101 vlan encap single-tagged vlan-id 101
+set / interface ethernet-1/5 subinterface 102 type bridged
+set / interface ethernet-1/5 subinterface 102 admin-state enable
+set / interface ethernet-1/5 subinterface 102 vlan encap single-tagged vlan-id 102
+set / interface ethernet-1/5 subinterface 103 type bridged
+set / interface ethernet-1/5 subinterface 103 admin-state enable
+set / interface ethernet-1/5 subinterface 103 vlan encap single-tagged vlan-id 103
+set / interface ethernet-1/5 subinterface 109 type bridged
+set / interface ethernet-1/5 subinterface 109 admin-state enable
+set / interface ethernet-1/5 subinterface 109 vlan encap single-tagged vlan-id 109
+set / interface ethernet-1/6 admin-state enable
+set / interface ethernet-1/6 vlan-tagging true
+set / interface ethernet-1/6 subinterface 101 type bridged
+set / interface ethernet-1/6 subinterface 101 admin-state enable
+set / interface ethernet-1/6 subinterface 101 vlan encap single-tagged vlan-id 101
+set / interface ethernet-1/6 subinterface 102 type bridged
+set / interface ethernet-1/6 subinterface 102 admin-state enable
+set / interface ethernet-1/6 subinterface 102 vlan encap single-tagged vlan-id 102
+set / interface ethernet-1/6 subinterface 103 type bridged
+set / interface ethernet-1/6 subinterface 103 admin-state enable
+set / interface ethernet-1/6 subinterface 103 vlan encap single-tagged vlan-id 103
+set / interface ethernet-1/6 subinterface 109 type bridged
+set / interface ethernet-1/6 subinterface 109 admin-state enable
+set / interface ethernet-1/6 subinterface 109 vlan encap single-tagged vlan-id 109
+set / network-instance bridge-vlan101 type mac-vrf
+set / network-instance bridge-vlan101 admin-state enable
+set / network-instance bridge-vlan101 interface ethernet-1/1.101
+set / network-instance bridge-vlan101 interface ethernet-1/3.101
+set / network-instance bridge-vlan101 interface ethernet-1/5.101
+set / network-instance bridge-vlan101 interface ethernet-1/6.101
+set / network-instance bridge-vlan102 type mac-vrf
+set / network-instance bridge-vlan102 admin-state enable
+set / network-instance bridge-vlan102 interface ethernet-1/2.102
+set / network-instance bridge-vlan102 interface ethernet-1/4.102
+set / network-instance bridge-vlan102 interface ethernet-1/5.102
+set / network-instance bridge-vlan102 interface ethernet-1/6.102
+set / network-instance bridge-vlan103 type mac-vrf
+set / network-instance bridge-vlan103 admin-state enable
+set / network-instance bridge-vlan103 interface ethernet-1/3.103
+set / network-instance bridge-vlan103 interface ethernet-1/4.103
+set / network-instance bridge-vlan103 interface ethernet-1/5.103
+set / network-instance bridge-vlan103 interface ethernet-1/6.103
+set / network-instance bridge-vlan109 type mac-vrf
+set / network-instance bridge-vlan109 admin-state enable
+set / network-instance bridge-vlan109 interface ethernet-1/3.109
+set / network-instance bridge-vlan109 interface ethernet-1/4.109
+set / network-instance bridge-vlan109 interface ethernet-1/5.109
+set / network-instance bridge-vlan109 interface ethernet-1/6.109
+```
 
 ### LACP Link aggregation
  To setup LACP link-aggregations, Ethernet interfaces need to be set to be members of a lag as follows:
 
-    set / interface ethernet-1/49 admin-state enable
-    set / interface ethernet-1/49 ethernet aggregate-id lag1
-    set / interface ethernet-1/50 admin-state enable
-    set / interface ethernet-1/50 ethernet aggregate-id lag1
-    set / interface ethernet-1/51 admin-state enable
-    set / interface ethernet-1/51 ethernet aggregate-id lag1
-    set / interface ethernet-1/52 admin-state enable
-    set / interface ethernet-1/52 ethernet aggregate-id lag1
+```bash
+set / interface ethernet-1/49 admin-state enable
+set / interface ethernet-1/49 ethernet aggregate-id lag1
+set / interface ethernet-1/50 admin-state enable
+set / interface ethernet-1/50 ethernet aggregate-id lag1
+set / interface ethernet-1/51 admin-state enable
+set / interface ethernet-1/51 ethernet aggregate-id lag1
+set / interface ethernet-1/52 admin-state enable
+set / interface ethernet-1/52 ethernet aggregate-id lag1
+```
 
  The name "lag1" is arbitrary--"lag1" is used in this example just as a reminder that this is the first LAG setup on this switch.
 
  Next, the lag-type has to be set to LACP, the member-speed target has to be set, and the LACP admin-key has to be set:
 
-    set / interface lag1 lag lag-type lacp
-    set / interface lag1 lag member-speed 10G
-    set / interface lag1 lag lacp admin-key 1
+```bash
+set / interface lag1 lag lag-type lacp
+set / interface lag1 lag member-speed 10G
+set / interface lag1 lag lacp admin-key 1
+```
 
  Then then subinterfaces for the lag have to be defined as described above for Ethernet interfaces.  In this example VLANs 101, 102, 103 and 109 are all set as tagged:
 
-    set / interface lag1 admin-state enable
-    set / interface lag1 vlan-tagging true
-    set / interface lag1 subinterface 101 type bridged
-    set / interface lag1 subinterface 101 admin-state enable
-    set / interface lag1 subinterface 101 vlan encap  single-tagged vlan-id 101
-    set / interface lag1 subinterface 102 type bridged
-    set / interface lag1 subinterface 102 admin-state enable
-    set / interface lag1 subinterface 102 vlan encap  single-tagged vlan-id 102
-    set / interface lag1 subinterface 103 type bridged
-    set / interface lag1 subinterface 103 admin-state enable
-    set / interface lag1 subinterface 103 vlan encap  single-tagged vlan-id 103
-    set / interface lag1 subinterface 109 type bridged
-    set / interface lag1 subinterface 109 admin-state enable
-    set / interface lag1 subinterface 109 vlan encap  single-tagged vlan-id 109
+```bash
+set / interface lag1 admin-state enable
+set / interface lag1 vlan-tagging true
+set / interface lag1 subinterface 101 type bridged
+set / interface lag1 subinterface 101 admin-state enable
+set / interface lag1 subinterface 101 vlan encap  single-tagged vlan-id 101
+set / interface lag1 subinterface 102 type bridged
+set / interface lag1 subinterface 102 admin-state enable
+set / interface lag1 subinterface 102 vlan encap  single-tagged vlan-id 102
+set / interface lag1 subinterface 103 type bridged
+set / interface lag1 subinterface 103 admin-state enable
+set / interface lag1 subinterface 103 vlan encap  single-tagged vlan-id 103
+set / interface lag1 subinterface 109 type bridged
+set / interface lag1 subinterface 109 admin-state enable
+set / interface lag1 subinterface 109 vlan encap  single-tagged vlan-id 109
+```
 
  And finally the subinterfaces of the lag have to be associated with a network instance as with the subinterfaces of an Ethernet interface:
 
-    set / network-instance bridge-vlan101 type mac-vrf
-    set / network-instance bridge-vlan101 admin-state enable
-    set / network-instance bridge-vlan101 interface ethernet-1/10.101
-    set / network-instance bridge-vlan101 interface ethernet-1/11.101
-    set / network-instance bridge-vlan101 interface ethernet-1/12.101
-    set / network-instance bridge-vlan101 interface ethernet-1/13.101
-    set / network-instance bridge-vlan101 interface ethernet-1/16.101
-    set / network-instance bridge-vlan101 interface ethernet-1/18.101
-    set / network-instance bridge-vlan101 interface ethernet-1/19.101
-    set / network-instance bridge-vlan101 interface ethernet-1/21.101
-    set / network-instance bridge-vlan101 interface ethernet-1/22.101
-    set / network-instance bridge-vlan101 interface ethernet-1/23.101
-    set / network-instance bridge-vlan101 interface ethernet-1/24.101
-    set / network-instance bridge-vlan101 interface ethernet-1/37.101
-    set / network-instance bridge-vlan101 interface ethernet-1/40.101
-    set / network-instance bridge-vlan101 interface ethernet-1/45.101
-    set / network-instance bridge-vlan101 interface ethernet-1/46.101
-    set / network-instance bridge-vlan101 interface ethernet-1/47.101
-    set / network-instance bridge-vlan101 interface lag1.101
+```bash
+set / network-instance bridge-vlan101 type mac-vrf
+set / network-instance bridge-vlan101 admin-state enable
+set / network-instance bridge-vlan101 interface ethernet-1/10.101
+set / network-instance bridge-vlan101 interface ethernet-1/11.101
+set / network-instance bridge-vlan101 interface ethernet-1/12.101
+set / network-instance bridge-vlan101 interface ethernet-1/13.101
+set / network-instance bridge-vlan101 interface ethernet-1/16.101
+set / network-instance bridge-vlan101 interface ethernet-1/18.101
+set / network-instance bridge-vlan101 interface ethernet-1/19.101
+set / network-instance bridge-vlan101 interface ethernet-1/21.101
+set / network-instance bridge-vlan101 interface ethernet-1/22.101
+set / network-instance bridge-vlan101 interface ethernet-1/23.101
+set / network-instance bridge-vlan101 interface ethernet-1/24.101
+set / network-instance bridge-vlan101 interface ethernet-1/37.101
+set / network-instance bridge-vlan101 interface ethernet-1/40.101
+set / network-instance bridge-vlan101 interface ethernet-1/45.101
+set / network-instance bridge-vlan101 interface ethernet-1/46.101
+set / network-instance bridge-vlan101 interface ethernet-1/47.101
+set / network-instance bridge-vlan101 interface lag1.101
+```
 
 ## nodesensors current, voltage and power reporting for Nokia switches
  Currently nodesensors reports 0 for input current, voltage and power for Nokia 7215 IXS-A1, 7220 IXR-D2L and 7220 IXR-D3L switches:
 
-    [root@n790 ~]# nodesensors switch173
-    switch173: Slot A Temperature: 36 °C
-    switch173: Fan Tray 6: 51 %
-    switch173: Fan Tray 6: 51 %
-    switch173: Fan Tray 6: 51 %
-    switch173: Fan Tray 6: 51 %
-    switch173: Fan Tray 6: 51 %
-    switch173: Fan Tray 6: 51 %
-    switch173: Power Supply 1 Health:
-    switch173: Power Supply 1 Temperature: 33 °C
-    switch173: Power Supply 1 Current: 0.00 A
-    switch173: Power Supply 1 Power: 0.00 W
-    switch173: Power Supply 1 Voltage: 0.00 V
-    switch173: Power Supply 2 Health:
-    switch173: Power Supply 2 Temperature: 30 °C
-    switch173: Power Supply 2 Current: 0.00 A
-    switch173: Power Supply 2 Power: 0.00 W
-    switch173: Power Supply 2 Voltage: 0.00 V
+```bash
+[root@n790 ~]# nodesensors switch173
+switch173: Slot A Temperature: 36 °C
+switch173: Fan Tray 6: 51 %
+switch173: Fan Tray 6: 51 %
+switch173: Fan Tray 6: 51 %
+switch173: Fan Tray 6: 51 %
+switch173: Fan Tray 6: 51 %
+switch173: Fan Tray 6: 51 %
+switch173: Power Supply 1 Health:
+switch173: Power Supply 1 Temperature: 33 °C
+switch173: Power Supply 1 Current: 0.00 A
+switch173: Power Supply 1 Power: 0.00 W
+switch173: Power Supply 1 Voltage: 0.00 V
+switch173: Power Supply 2 Health:
+switch173: Power Supply 2 Temperature: 30 °C
+switch173: Power Supply 2 Current: 0.00 A
+switch173: Power Supply 2 Power: 0.00 W
+switch173: Power Supply 2 Voltage: 0.00 V
+```
 
- 

--- a/docs/miscellaneous/nvidiagpudriverinstall.md
+++ b/docs/miscellaneous/nvidiagpudriverinstall.md
@@ -2,13 +2,13 @@
 title: NVIDIA GPU Driver Install on RHEL 9.5 and Ubuntu 24.04.2
 ---
 
-# NVIDIA GPU Driver Install on RHEL 9.5
+## NVIDIA GPU Driver Install on RHEL 9.5
 
-## Notes
+### Notes
  The following procedure is for installing the NVIDIA GPU drivers on RHEL 9.5.  Note that this is for a single-node install.  Scale with nodeshell and arguments to make these steps unattended as needed.
 
 
-## Register and subscribe a RHEL system to the Red Hat Customer Portal using Red Hat Subscription-Manager
+### Register and subscribe a RHEL system to the Red Hat Customer Portal using Red Hat Subscription-Manager
  This is required because some of the packages required are only available for registered systems. 
  ```
  subscription-manager register --username <username> --password <password> 
@@ -22,96 +22,96 @@ title: NVIDIA GPU Driver Install on RHEL 9.5 and Ubuntu 24.04.2
  ```
 
 
-## Prerequisites
+### Prerequisites
  DOCA must be installed ***before*** installing the GPU drivers to make sure the nvidia-peermem kernel module gets the right Infiniband symbols.
 
-## Enable update repos
+### Enable update repos
  ```
  subscription-manager repos --enable=rhel-9-for-x86_64-baseos-rpms
  subscription-manager repos --enable=rhel-9-for-x86_64-appstream-rpms
  ```
 
 
-## Install newer kernel packages
+### Install newer kernel packages
  Note that these steps install a new version as opposed to replacing the older kernel version(s), so the system can be booted to the older kernel version(s) if needed.
  ```
  dnf install kernel kernel-core kernel-modules-core kernel-modules 
  ```
 
 
-## Install newer kernel devel packages
+### Install newer kernel devel packages
  Note that these steps install a new version as opposed to replacing the older kernel version(s), so the system can be booted to the older kernel version(s) if needed.
  ```
  dnf install kernel-devel kernel-devel-matched kernel-headers kernel-modules-extra
  ```
 
 
-## Update kernel tools and kernel abi stablelists
+### Update kernel tools and kernel abi stablelists
  Note that this still will update the existing kernel tools packages, as multiple versions of these kernel tools on the system as the same time.
  ```
  dnf install kernel-tools kernel-tools-libs kernel-abi-stablelists
  ```
 
 
-## Install dkms
+### Install dkms
  ```
  dnf install dkms
  ```
 
 
-## Disable update repos
+### Disable update repos
  ```
  subscription-manager repos --disable=rhel-9-for-x86_64-appstream-rpms
  subscription-manager repos --disable=rhel-9-for-x86_64-baseos-rpms
  ```
 
 
-## Reboot the system using the newly installed kernel
+### Reboot the system using the newly installed kernel
  ```
  reboot
  ```
 
 
-## Install GPU driver local repo
+### Install GPU driver local repo
  ```
  rpm -ivh <path to nvidia local repo RPM>/nvidia-driver-local-repo-rhel9-570.124.06-1.0-1.x86_64.rpm
  ```
 
 
-## Clean DNF/YUM cache
+### Clean DNF/YUM cache
  ```
  dnf clean all
  ```
 
 
-## Backup grub.cfg from ESP
+### Backup grub.cfg from ESP
  When installing the nvidia-kmod-common package from the NVIDIA 570.124.06 local driver repo on RHEL 9.5 on an EFI-booted system, the /boot/efi/EFI/redhat/grub.cfg file, which is a "stub" grub.cfg in the EFI system partition (ESP) that only points to /boot/grub2 for the full grub.cfg, is overwritten with a full grub.cfg and the grub.cfg in /boot/grub2 is not updated.  To work around this, backup the grub.cfg in the ESP (this will be restored and the grub.cfg file in /boot/grub2 fixed after installing the GPU drivers):
  ```
  cp /boot/efi/EFI/redhat/grub.cfg ~/grub.cfg.PRE-NVIDIA
  ```
 
 
-## Install GPU drivers
+### Install GPU drivers
  **Note** The nvidia-fabric-manager package is only necesssary on 8-GPU HGX configs.
  ```
  dnf install nvidia-driver-cuda kmod-nvidia-open-dkms nvidia-fabric-manager
  ```
 
 
-## Restore backed up stub grub.cfg and fix grub.cfg in /boot/grub2
+### Restore backed up stub grub.cfg and fix grub.cfg in /boot/grub2
  ```
  cp -f /boot/efi/EFI/redhat/grub.cfg /boot/grub2
  cp -f ~/grub.cfg.PRE-NVIDIA /boot/efi/EFI/redhat95/grub.cfg
  ```
 
 
-## Reboot
+### Reboot
  ```
  reboot
  ```
 
 
-## Check driver status
+### Check driver status
  The following should show the correct driver version installed for the correct kernel version:
  ```
  dkms status
@@ -130,13 +130,13 @@ title: NVIDIA GPU Driver Install on RHEL 9.5 and Ubuntu 24.04.2
  ```
 
 
-## Make sure the version of the nvidia driver running is correct:
+### Make sure the version of the nvidia driver running is correct:
  ```
  cat /sys/module/nvidia/version
  ```
 
 
-## Start the nvidia-persistenced service and make sure its running OK:
+### Start the nvidia-persistenced service and make sure its running OK:
  ```
  systemctl start nvidia-persistenced
  systemctl status nvidia-persistenced
@@ -148,19 +148,19 @@ title: NVIDIA GPU Driver Install on RHEL 9.5 and Ubuntu 24.04.2
  ```
 
 
-## Check that nvidia-smi reports all expected GPUs:
+### Check that nvidia-smi reports all expected GPUs:
  ```
  nvidia-smi
  ```
 
 
-## Check the NVLINKs (where applicable--this applies to all HGX systems and systems with PCIe GPUs with NVLINK bridge cards installed).  All expected links should show up at expected bandwidth:
+### Check the NVLINKs (where applicable--this applies to all HGX systems and systems with PCIe GPUs with NVLINK bridge cards installed).  All expected links should show up at expected bandwidth:
  ``` 
  nvidia-smi nvlink -s
  ```
 
 
-## Check the NVLINK fabric status (applicable for HGX 8-way configurations)
+### Check the NVLINK fabric status (applicable for HGX 8-way configurations)
  ```
  nvidia-smi -q -i 0 | grep -i -A 2 Fabric
  ```
@@ -181,26 +181,26 @@ title: NVIDIA GPU Driver Install on RHEL 9.5 and Ubuntu 24.04.2
 <br>
 
 
-# NVIDIA GPU Driver Install on Ubuntu 24.04.2
+## NVIDIA GPU Driver Install on Ubuntu 24.04.2
 
-## Notes
+### Notes
  The following procedure is for installing the NVIDIA GPU drivers on Ubuntu 24.04.2.
  
  **NOTE** This is for a single-node install. Scale with nodeshell.  Arguments to make these steps unattended have been included.
 
-## Install the NVIDIA driver local repo
+### Install the NVIDIA driver local repo
  Install the NVIDIA driver local repo package.  Note that while this can be redundant with the CUDA local repo package, since the CUDA local repo package also contains the NVIDIA drivers, there can be cases where a different version of the NVIDIA driver from that contained in the version of CUDA that is being used is desired.  Because of that, this procedure details installing the NVIDIA GPU drivers from the NVIDIA driver local repo.
  ```
  dpkg -i /cluster/drivers/nvidia/570.124.06/nvidia-driver-local-repo-ubuntu2404-570.124.06_1.0-1_amd64.deb
  ```
 
-## Enroll the NVIDIA driver local repo GPG key
+### Enroll the NVIDIA driver local repo GPG key
  Enroll the GPG key for the NVIDIA driver local repo:
  ```
  cp /var/nvidia-driver-local-repo-ubuntu2404-570.124.06/nvidia-driver-local-D67F55A1-keyring.gpg /usr/share/keyrings/
  ```
 
-## Pin the NVIDIA GPU driver version to that from the NVIDIA GPU driver local repo
+### Pin the NVIDIA GPU driver version to that from the NVIDIA GPU driver local repo
  The Ubuntu 24.04 OS repos contain many versions of the NVIDIA GPU drivers.  To make sure the version installed is the one from the NVIDIA GPU driver local repo installed above, pin the version as follows (note that in this case the 570.124.06 NVIDIA GPU driver version is being used):
  ```
  cat << EOF > /etc/apt/preferences.d/nvidia
@@ -210,13 +210,13 @@ title: NVIDIA GPU Driver Install on RHEL 9.5 and Ubuntu 24.04.2
  EOF
  ```
 
-## Update the apt repo cache
+### Update the apt repo cache
  Update the apt repo cache for the newly installed NVIDIA driver local repo:
  ```
  DEBIAN_FRONTEND=noninteractive apt-get update -y
  ```
 
-## Install the NVIDIA GPU driver packages
+### Install the NVIDIA GPU driver packages
  Install the NVIDIA GPU driver packages.  The following examples will install the minimal number of packages necessary, suitable for a light-weight compute node install.  **Note** that this step should be done **after** DOCA is installed, otherwise the nvidia-peermem module will not be compiled with the correct InfiniBand support and may fail to load.
 
  In most cases the open drivers should be installed, as follows:
@@ -228,7 +228,7 @@ title: NVIDIA GPU Driver Install on RHEL 9.5 and Ubuntu 24.04.2
  DEBIAN_FRONTEND=noninteractive apt-get install -V -y libnvidia-compute-570 nvidia-dkms-570 nvidia-compute-utils-570 nvidia-utils-570 libnvidia-cfg1-570
  ```
 
-## Extract the contents of the CUDA local repo package
+### Extract the contents of the CUDA local repo package
  The CUDA repo is required to install the GPU Direct Storage (GDS) kernel module and utility packages. While the CUDA local repo package can simply be installed locally on each compute node, this can take up a lot of local storage space.  A more efficient way of making the CUDA local repo available to all compute nodes is to extract the files from the CUDA local repo package to a network share available to all compute nodes.  In the following example, the `/cluster` directory is the network share mounted on all compute notes, the CUDA local repo package has been placed in the `/cluster/software/cuda/12.8.1` directory, and the `/cluster/software/cuda/12.8.1/ubuntu-repo` directory is the location where the CUDA local repo contents will reside.
  ```
  cd /cluster/software/cuda/12.8.1
@@ -236,25 +236,25 @@ title: NVIDIA GPU Driver Install on RHEL 9.5 and Ubuntu 24.04.2
  dpkg-deb -x cuda-repo-ubuntu2404-12-8-local_12.8.1-570.124.06-1_amd64.deb ubuntu-repo
  ```
 
-## Enroll the CUDA local repo GPG key
+### Enroll the CUDA local repo GPG key
  Enroll the GPG key for the CUDA local repo:
  ```
  cp /cluster/software/cuda/12.8.1/ubuntu-repo/var/cuda-repo-ubuntu2404-12-8-local/cuda-B2775641-keyring.gpg /usr/share/keyrings/
  ```
 
-## Prioritize the CUDA local repo:
+### Prioritize the CUDA local repo:
  To prioritize the CUDA local repo, run the following (note the cuda-ubuntu-2404.pin file has been placed in the `/cluster/software/cuda/12.8.1/` directory in this case):
  ```
  cp /cluster/software/cuda/12.8.1/cuda-ubuntu2404.pin /etc/apt/preferences.d/cuda-repository-pin-600
  ```
 
-## Copy the CUDA repo doc files locally
+### Copy the CUDA repo doc files locally
   Installing the CUDA local repo, aside from setting up the repo itself, does install the docs for the repo.  To replicate this in the case that the CUDA local repo package wasn't actually installed, the doc files can be copied into place.  The following command will do that, using the example directories: 
  ```
  cp -a /cluster/software/cuda/12.8.1/ubuntu-repo/usr/share/doc/cuda-repo-ubuntu2404-12-8-local /usr/share/doc
  ```
 
-## Setup apt repo list file for CUDA local repo
+### Setup apt repo list file for CUDA local repo
  Since the CUDA local repo package wasn't actually installed, an apt repo list file has to be created to enable the CUDA local repo package contents extracted onto the network share in the step above.  The following commands will set that up for the example path:
  ```
  cat << EOF > /etc/apt/sources.list.d/cuda-ubuntu2404-12-8-local.list
@@ -262,39 +262,39 @@ title: NVIDIA GPU Driver Install on RHEL 9.5 and Ubuntu 24.04.2
  EOF
  ```
 
-## Update the apt repo cache
+### Update the apt repo cache
  Update the apt repo cache for the newly installed CUDA local repo:
  ```
  DEBIAN_FRONTEND=noninteractive apt-get update -y
  ```
 
-## Install the GDS kernel module package
+### Install the GDS kernel module package
  ```
  DEBIAN_FRONTEND=noninteractive apt-get install -V -y nvidia-fs
  ```
 
-## Install the GDS utility packages
+### Install the GDS utility packages
  ```
  DEBIAN_FRONTEND=noninteractive apt-get install -V -y nvidia-gds
  ```
 
-## **OPTIONAL** Install the nvidia-fabric manager packages
+### **OPTIONAL** Install the nvidia-fabric manager packages
  ```
  DEBIAN_FRONTEND=noninteractive apt-get install -V -y nvidia-fabricmanager-570 libnvidia-nscq-570 nvidia-imex-570
  ```
 
-## **OPTIONAL** Install additional nvidia-fabric manager packages for B200
+### **OPTIONAL** Install additional nvidia-fabric manager packages for B200
  ```
  DEBIAN_FRONTEND=noninteractive apt-get install -V -y /cluster/drivers/nvidia/570.124.06/nvlsm_2025.01.5-1_amd64.deb
  ```
 
-## Reboot
+### Reboot
  ```
  reboot
  ```
 
 
-## Check driver status
+### Check driver status
  The following should show the correct driver version installed for the correct kernel version:
  ```
  dkms status
@@ -313,13 +313,13 @@ title: NVIDIA GPU Driver Install on RHEL 9.5 and Ubuntu 24.04.2
  ```
 
 
-## Make sure the version of the nvidia driver running is correct:
+### Make sure the version of the nvidia driver running is correct:
  ```
  cat /sys/module/nvidia/version
  ```
 
 
-## Start the nvidia-persistenced service and make sure its running OK:
+### Start the nvidia-persistenced service and make sure its running OK:
  ```
  systemctl start nvidia-persistenced
  systemctl status nvidia-persistenced
@@ -331,19 +331,19 @@ title: NVIDIA GPU Driver Install on RHEL 9.5 and Ubuntu 24.04.2
  ```
 
 
-## Check that nvidia-smi reports all expected GPUs:
+### Check that nvidia-smi reports all expected GPUs:
  ```
  nvidia-smi
  ```
 
 
-## Check the NVLINKs (where applicable--this applies to all HGX systems and systems with PCIe GPUs with NVLINK bridge cards installed).  All expected links should show up at expected bandwidth:
+### Check the NVLINKs (where applicable--this applies to all HGX systems and systems with PCIe GPUs with NVLINK bridge cards installed).  All expected links should show up at expected bandwidth:
  ``` 
  nvidia-smi nvlink -s
  ```
 
 
-## Check the NVLINK fabric status (applicable for HGX 8-way configurations)
+### Check the NVLINK fabric status (applicable for HGX 8-way configurations)
  ```
  nvidia-smi -q -i 0 | grep -i -A 2 Fabric
  ```

--- a/docs/miscellaneous/osdeploysecurity.md
+++ b/docs/miscellaneous/osdeploysecurity.md
@@ -1,5 +1,8 @@
 ---
 title: Handling of security information in OS deployment
+tags:
+  - security
+  - deployment
 ---
 
 ## SSH host and user authentication

--- a/docs/miscellaneous/osdeploysecurity.md
+++ b/docs/miscellaneous/osdeploysecurity.md
@@ -2,7 +2,7 @@
 title: Handling of security information in OS deployment
 ---
 
-# SSH host and user authentication
+## SSH host and user authentication
 
 In confluent, hosts are given SSH certificates when required to vouch for their identity. /etc/ssh/shosts.equiv and /etc/ssh/ssh_known_hosts
 are configured to facilitate node to node ssh without working about known_hosts and to enable host based authentication of users. This
@@ -17,14 +17,14 @@ within a confluent install (e.g. skipping setting up ~/.ssh/authorized_keys and 
 One exception to this is that root and syncfiles/ansible ssh user keys are added to the local root user to provide management and automation
 regardless of host based authentication state.
 
-# syncfiles facility
+## syncfiles facility
 
 The syncfiles facility allows content from deployment server to be copied to a target node in flexible ways. The source content may be located
 anywhere on the deployment server, but must be accessible by the `confluent` user, as `confluent` does not run as `root`.  It may be convenient
 to use `sudo -u confluent bash` to examine files for access if you receive errors about inaccessible files. This may be used to convey more sensitive
 data by allowing confluent, but not other users to read the information
 
-# Content in /var/lib/confluent/private/
+## Content in /var/lib/confluent/private/
 
 The confluent api offers material in /var/lib/confluent/private to nodes that authenticate using their node api key. For example, confluent uses
 this facility to provide the encryption key for encrypted diskless images and disk cloning. Custom scripts may use this facility. For example, if wanting to provide some sort of /etc/shadow entry for an account using the private facility:
@@ -36,7 +36,7 @@ this facility to provide the encryption key for encrypted diskless images and di
 $5$ssdUjvVexCw50Nvc$5uQMDLlikaiZKsTt4.8Xmlmr/O7qNXTrlBgnc20CQb7  
 ```
 
-# API calls
+## API calls
 
 Confluent API calls provide information for deployment authenticated by the node API key.  For example in conjunction with custom node attributes, data can be stored and
 accessed in an authenticated fashion:
@@ -47,7 +47,7 @@ accessed in an authenticated fashion:
     [root@d11 ~]# python3 /opt/confluent/bin/apiclient /confluent-api/self/myattribs|grep custom.mysecret
     custom.mysecret: area51
 
-# Content in /var/lib/confluent/public is considered public
+## Content in /var/lib/confluent/public is considered public
 
 Material is published without authentication from /var/lib/confluent/public, and thus sensitive information such as passwords or private keys should be avoided, and instead syncfiles, profile private area, or node attributes should be used.
 One borderline scenario is diskless and cloned images.  Confluent attempts to strip well known confidential information during capture or pack (e.g. shadow and private ssh keys), but custom OS content

--- a/docs/miscellaneous/proxmoxguide.md
+++ b/docs/miscellaneous/proxmoxguide.md
@@ -15,32 +15,42 @@ For proxmox, start by creating a debian profile for confluent.  Grab the `mini.i
 
 With this downloaded, import it using osdeploy:
 
-    # osdeploy import mini.iso 
-    Importing from /tmp/debian/mini.iso to /var/lib/confluent/distributions/debian-13.4-x86_64
-    complete: 100.00%    
-    Deployment profile created: debian-13.4-x86_64-default
+```bash
+# osdeploy import mini.iso 
+Importing from /tmp/debian/mini.iso to /var/lib/confluent/distributions/debian-13.4-x86_64
+complete: 100.00%    
+Deployment profile created: debian-13.4-x86_64-default
+```
 
 It is suggested to make a copy of the profile to customize for proxmox:
 
-    # cd /var/lib/confluent/public/os/
-    # cp -a debian-13.4-x86_64-default/ debian-13.4-x86_64-proxmox
+```bash
+# cd /var/lib/confluent/public/os/
+# cp -a debian-13.4-x86_64-default/ debian-13.4-x86_64-proxmox
+```
 
 Enable the provided example proxmox scripts:
 
-    # cd /var/lib/confluent/public/os/debian-13.4-x86_64-proxmox/
-    # cp scripts/proxmox/proxmoxve.firstboot scripts/firstboot.d/
-    # cp scripts/proxmox/proxmoxve.post scripts/post.d/
+```bash
+# cd /var/lib/confluent/public/os/debian-13.4-x86_64-proxmox/
+# cp scripts/proxmox/proxmoxve.firstboot scripts/firstboot.d/
+# cp scripts/proxmox/proxmoxve.post scripts/post.d/
+```
 
 Now the profile is ready to be deployed, just like any other profile:
 
-    # nodedeploy pmx8 -n debian-13.4-x86_64-proxmox 
-    pmx8: network
-    pmx8: on
+```bash
+# nodedeploy pmx8 -n debian-13.4-x86_64-proxmox 
+pmx8: network
+pmx8: on
+```
 
 Note that proxmox may lengthen the post and firstboot phases a bit, wait until you see:
 
-    # nodedeploy pmx8
-    pmx8: completed: debian-13.4-x86_64-proxmox
+```bash
+# nodedeploy pmx8
+pmx8: completed: debian-13.4-x86_64-proxmox
+```
 
 ## Using proxmox virtual machines as nodes
 
@@ -107,64 +117,78 @@ Review settings and click 'Finish' to create the VM
 
 The following is an example using the CLI to create a VM instead of the WebUI (with TPM2, 96GB disk, 8 cores, 16GB of RAM):
 
-    # qm create 101 --name pvm2 --ostype l26 --scsihw virtio-scsi-single --tpmstate0 local:1,version=v2.0 -scsi0 local:96,format=qcow2,iothread=on,cache=writeback --sockets 1 --cores 8 --numa 0 --cpu host --memory 16384 --net0 virtio,bridge=vmbr0,firewall=1
-    Formatting '/var/lib/vz/images/101/vm-101-disk-0.qcow2', fmt=qcow2 cluster_size=65536 extended_l2=off   preallocation=metadata compression_type=zlib size=103079215104 lazy_refcounts=off refcount_bits=16
-    scsi0: successfully created disk 'local:101/vm-101-disk-0.qcow2,cache=writeback,iothread=1,size=96G'
-    Formatting '/var/lib/vz/images/101/vm-101-disk-1.raw', fmt=raw size=4194304 preallocation=off
-    tpmstate0: successfully created disk 'local:101/vm-101-disk-1.raw,size=4M,version=v2.0'
+```bash
+# qm create 101 --name pvm2 --ostype l26 --scsihw virtio-scsi-single --tpmstate0 local:1,version=v2.0 -scsi0 local:96,format=qcow2,iothread=on,cache=writeback --sockets 1 --cores 8 --numa 0 --cpu host --memory 16384 --net0 virtio,bridge=vmbr0,firewall=1
+Formatting '/var/lib/vz/images/101/vm-101-disk-0.qcow2', fmt=qcow2 cluster_size=65536 extended_l2=off   preallocation=metadata compression_type=zlib size=103079215104 lazy_refcounts=off refcount_bits=16
+scsi0: successfully created disk 'local:101/vm-101-disk-0.qcow2,cache=writeback,iothread=1,size=96G'
+Formatting '/var/lib/vz/images/101/vm-101-disk-1.raw', fmt=raw size=4194304 preallocation=off
+tpmstate0: successfully created disk 'local:101/vm-101-disk-1.raw,size=4M,version=v2.0'
+```
 
 
 ## Configuring confluent for using the proxmox VMs as nodes
 
 First, if it doesn't already exist as a confluent node, define a node using the name of the proxmox host:
 
-    # nodedefine pmx8
-    pmx8: created
+```bash
+# nodedefine pmx8
+pmx8: created
+```
 
 Create a node as you normally would.  A terse example assuming existing general group settings and focusing solely on the proxmox facet:
 
-    # nodedefine pvm1 hardwaremanagement.method=proxmox bmcuser=root@pam hardwaremanagement.manager=pmx8
-    pvm1: created
-    # nodeattrib pvm1 -p bmcpass
-    Enter value for bmcpass: 
-    Confirm value for bmcpass: 
-    pvm1: secret.hardwaremanagementpassword: ********
+```bash
+# nodedefine pvm1 hardwaremanagement.method=proxmox bmcuser=root@pam hardwaremanagement.manager=pmx8
+pvm1: created
+# nodeattrib pvm1 -p bmcpass
+Enter value for bmcpass: 
+Confirm value for bmcpass: 
+pvm1: secret.hardwaremanagementpassword: ********
+```
 
 Here's an alternative including other node setup attributes explicitly rather than inheriting from `everything` as above:
 
-    # nodedefine pvm2 hardwaremanagement.method=proxmox bmcuser=root@pam hardwaremanagement.manager=pmx8 net.ipv4_address=172.30.84.{id.index%255} deployment.useinsecureprotocols=firmware dns.domain=devcluster.net dns.servers=172.30.193.20
-    pvm2: created
-    # nodeattrib pvm2 -p crypted.rootpassword bmcpass
-    Enter value for crypted.rootpassword: 
-    Confirm value for crypted.rootpassword: 
-    Enter value for bmcpass: 
-    Confirm value for bmcpass: 
-    pvm2: ********
-    pvm2: crypted.rootpassword: ********
-    pvm2: secret.hardwaremanagementpassword: ********
+```bash
+# nodedefine pvm2 hardwaremanagement.method=proxmox bmcuser=root@pam hardwaremanagement.manager=pmx8 net.ipv4_address=172.30.84.{id.index%255} deployment.useinsecureprotocols=firmware dns.domain=devcluster.net dns.servers=172.30.193.20
+pvm2: created
+# nodeattrib pvm2 -p crypted.rootpassword bmcpass
+Enter value for crypted.rootpassword: 
+Confirm value for crypted.rootpassword: 
+Enter value for bmcpass: 
+Confirm value for bmcpass: 
+pvm2: ********
+pvm2: crypted.rootpassword: ********
+pvm2: secret.hardwaremanagementpassword: ********
+```
 
 To push the ipv4 addresses from net attributes to /etc/hosts:
 
-    # confluent2hosts -a pvm1,pvm2
-    # getent hosts pvm2
-    172.30.84.130   pvm2 pvm2.devcluster.net
+```bash
+# confluent2hosts -a pvm1,pvm2
+# getent hosts pvm2
+172.30.84.130   pvm2 pvm2.devcluster.net
+```
 
 Next, have confluent gather needed information about the virtual machines, similar to a manually added BMC-managed node:
 
-    # nodeinventory pvm[1,2] -s
+```bash
+# nodeinventory pvm[1,2] -s
+```
 
 The node is now ready for use as a normal node, for example, to boot a diskless profile I have built:
 
-    # nodedeploy pvm[1,2] -n alma-9.7-x86_64-diskless
+```bash
+# nodedeploy pvm[1,2] -n alma-9.7-x86_64-diskless
 
-    pvm2: network
-    pvm1: network
-    pvm2: on
-    pvm1: on
-    # sleep 30 # Just some time to let the VMs boot
-    # nodeshell pvm[1,2] hostname
-    pvm1: pvm1
-    pvm2: pvm2
+pvm2: network
+pvm1: network
+pvm2: on
+pvm1: on
+# sleep 30 # Just some time to let the VMs boot
+# nodeshell pvm[1,2] hostname
+pvm1: pvm1
+pvm2: pvm2
+```
 
 ## Confluent commands to work with Proxmox VMs
 
@@ -174,18 +198,20 @@ If you add a serial port to the VM, then you can use console.method=proxmox to h
 
 Nodeinventory also works:
 
-    # nodeinventory pvm[1,2]
-    pvm2: System Product name: Proxmox qemu virtual machine
-    pvm2: System Manufacturer: qemu
-    pvm2: System UUID: f7d1eab8-bb7b-4fc2-9dcb-5781e5a02c8b
-    pvm2: Network adapter net0 Type: Ethernet
-    pvm2: Network adapter net0 Model: virtio
-    pvm2: Network adapter net0 MAC Address 1: BC:24:11:25:82:89
-    pvm1: System Product name: Proxmox qemu virtual machine
-    pvm1: System Manufacturer: qemu
-    pvm1: System UUID: 20a9bd43-ff2e-4216-8c00-ce6c9e05d560
-    pvm1: Network adapter net0 Type: Ethernet
-    pvm1: Network adapter net0 Model: virtio
-    pvm1: Network adapter net0 MAC Address 1: BC:24:11:FF:33:88
+```bash
+# nodeinventory pvm[1,2]
+pvm2: System Product name: Proxmox qemu virtual machine
+pvm2: System Manufacturer: qemu
+pvm2: System UUID: f7d1eab8-bb7b-4fc2-9dcb-5781e5a02c8b
+pvm2: Network adapter net0 Type: Ethernet
+pvm2: Network adapter net0 Model: virtio
+pvm2: Network adapter net0 MAC Address 1: BC:24:11:25:82:89
+pvm1: System Product name: Proxmox qemu virtual machine
+pvm1: System Manufacturer: qemu
+pvm1: System UUID: 20a9bd43-ff2e-4216-8c00-ce6c9e05d560
+pvm1: Network adapter net0 Type: Ethernet
+pvm1: Network adapter net0 Model: virtio
+pvm1: Network adapter net0 MAC Address 1: BC:24:11:FF:33:88
+```
 
 As well as nodepower, nodesetboot, and by extension nodeboot. Other confluent commands are not supported at this time.

--- a/docs/miscellaneous/raid-vroc-template.md
+++ b/docs/miscellaneous/raid-vroc-template.md
@@ -21,23 +21,25 @@ Example file for software RAID/md RAID
 ---------------
 
 
-    DEVICES="/dev/sda /dev/sdb"
-    RAIDLEVEL=1
-    mdadm --detail /dev/md*|grep 'Version : 1.0' >& /dev/null && exit 0
-    lvm vgchange -a n
-    mdadm -S -s
-    NUMDEVS=$(for dev in $DEVICES; do
-       echo wipefs -a $dev
-    done|wc -l)
-    for dev in $DEVICES; do
-       wipefs -a $dev
-    done
-    # must use older metadata format to leave disks looking normal for uefi
-    mdadm -C /dev/md/raid $DEVICES -n $NUMDEVS -e 1.0 -l $RAIDLEVEL
-    # shut and restart array to prime things for anaconda
-    mdadm -S -s
-    mdadm --assemble --scan
-    readlink /dev/md/raid|sed -e 's/.*\///' > /tmp/installdisk
+```bash
+DEVICES="/dev/sda /dev/sdb"
+RAIDLEVEL=1
+mdadm --detail /dev/md*|grep 'Version : 1.0' >& /dev/null && exit 0
+lvm vgchange -a n
+mdadm -S -s
+NUMDEVS=$(for dev in $DEVICES; do
+   echo wipefs -a $dev
+done|wc -l)
+for dev in $DEVICES; do
+   wipefs -a $dev
+done
+# must use older metadata format to leave disks looking normal for uefi
+mdadm -C /dev/md/raid $DEVICES -n $NUMDEVS -e 1.0 -l $RAIDLEVEL
+# shut and restart array to prime things for anaconda
+mdadm -S -s
+mdadm --assemble --scan
+readlink /dev/md/raid|sed -e 's/.*\///' > /tmp/installdisk
+```
 
 
 Reference  <https://github.com/lenovo/confluent/blob/master/misc/swraid> 
@@ -49,21 +51,23 @@ Example file for VROC RAID:
 ---------------
 
 
-    DEVICES="/dev/sda /dev/sdb"
-    RAIDLEVEL=1
-    mdadm --detail /dev/md* | grep imsm >& /dev/null && exit 0
-    lvm vgchange -a n
-    mdadm -S -s
-    NUMDEVS=$(for dev in $DEVICES; do
-       echo wipefs -a $dev
-    done|wc -l)
-    for dev in $DEVICES; do
-       wipefs -a $dev
-    done
-    mdadm -C /dev/md/imsm0 $DEVICES -n $NUMDEVS -e imsm
-    mdadm -C /dev/md/md0_0 /dev/md/imsm0 -n $NUMDEVS -l $RAIDLEVEL
-    mdadm -S -s
-    mdadm --assemble --scan
+```bash
+DEVICES="/dev/sda /dev/sdb"
+RAIDLEVEL=1
+mdadm --detail /dev/md* | grep imsm >& /dev/null && exit 0
+lvm vgchange -a n
+mdadm -S -s
+NUMDEVS=$(for dev in $DEVICES; do
+   echo wipefs -a $dev
+done|wc -l)
+for dev in $DEVICES; do
+   wipefs -a $dev
+done
+mdadm -C /dev/md/imsm0 $DEVICES -n $NUMDEVS -e imsm
+mdadm -C /dev/md/md0_0 /dev/md/imsm0 -n $NUMDEVS -l $RAIDLEVEL
+mdadm -S -s
+mdadm --assemble --scan
+```
 
 
 Reference <https://github.com/lenovo/confluent/blob/master/misc/vroc> 

--- a/docs/miscellaneous/raid-vroc-template.md
+++ b/docs/miscellaneous/raid-vroc-template.md
@@ -2,13 +2,11 @@
 title: Template for RAID/VROC boot device 
 ---
 
-Synopsis
----------------
+## Synopsis
 
 Add software RAID/md RAID for RHEL/Rocky Linux/Alma Linux, and VROC support for booting devices for RHEL/Rocky Linux/Alma Linux and SLES. 
 
-Solution
----------------
+## Solution
 
 Confluent has a built-in feature to be able to load custom files in different parts of the booting process.
 
@@ -17,8 +15,7 @@ After editing the sample file, place it in **` /var/lib/confluent/public/os/<<pr
 
 For software RAID/md RAID instances please find below as a sample file may adapt for your needs:
 
-Example file for software RAID/md RAID
----------------
+## Example file for software RAID/md RAID
 
 
 ```bash
@@ -47,8 +44,7 @@ Reference  <https://github.com/lenovo/confluent/blob/master/misc/swraid>
 
 For VROC instances, please apply same principle as above (edit with needed info) :
 
-Example file for VROC RAID:
----------------
+## Example file for VROC RAID:
 
 
 ```bash

--- a/docs/miscellaneous/routeddeployment.md
+++ b/docs/miscellaneous/routeddeployment.md
@@ -10,7 +10,7 @@ with the least network.
 
 That said, there are a number of strategies to perform deployment through a router:
 
-# Remote media boot
+## Remote media boot
 
 You can use the remote media to boot a confluent image, in conjunction with an 'identity' image.
 
@@ -52,10 +52,11 @@ so it is advised to only use `upload`.
 ```
 # nodemedia rackmount attach https://172.30.193.20/confluent-public/os/rocky-9.4-x86_64-default/boot.img
 ```
-Note that attach is frequently needed, as boot.img is often larger than the space allowed by the xClarity Controller for upload. However, the boot.img should contain
-no particularly confidential information.
+!!! note
+    Attach is frequently needed, as boot.img is often larger than the space allowed by the xClarity Controller for upload. However, the boot.img should contain
+    no particularly confidential information.
 
-# URL driven remote boot using iPXE
+## URL driven remote boot using iPXE
 
 This approach has the local DHCP server handle chainloading iPXE and sending a URL parameter only to iPXE.
 
@@ -76,7 +77,7 @@ To proceed:
 - osdeploy updateboot [osimagename]
 - Have the local DHCP configuration ultimately tell iPXE to boot `http://[ip.of.confluent.server]/confluent-api/boot/by-uuid/${uuid}/ipxe` or `http://[ip.of.confluent.server]/confluent-api/boot/by-mac/${mac:hexhyp}/ipxe`, depending on whether you collected UUID or mac addresses previously
 
-# DHCP delegation of PXE
+## DHCP delegation of PXE
 
 This approach has the local DHCP server only handling addressing, and pointing the booting system towards confluent for further instructions
 

--- a/docs/miscellaneous/samplepostscripts.md
+++ b/docs/miscellaneous/samplepostscripts.md
@@ -3,7 +3,7 @@ title: Osdeployment sample postscripts and their usage
 ---
 
 Listed here are some sample post scripts that you might choose to use when deploying 
-confluent surported operating systems. These scripts are located in the initialized 
+confluent supported operating systems. These scripts are located in the initialized 
 profiles scripts directory, `/var/lib/confluent/public/os/<profile>/scripts/sample`.
 
 1. **Post script to comment out the terminal and serial lines in the grub.conf after install on el9 or suse15**

--- a/docs/miscellaneous/sd650sharednote.md
+++ b/docs/miscellaneous/sd650sharednote.md
@@ -7,4 +7,6 @@ to induce bmcsetup to correctly move the XCC to the shared port.
 
 The value can be set by the following command, if your SD650 are in a group called `dwc`:
 
-    nodegrpch dwc ipmi.bmcport=`0 2'
+```bash
+nodegrpch dwc ipmi.bmcport=`0 2'
+```

--- a/docs/miscellaneous/sshdesign.md
+++ b/docs/miscellaneous/sshdesign.md
@@ -2,18 +2,18 @@
 title: Confluent SSH Configuration
 ---
 
-# SSH authentication architecture as configured by confluent
+## SSH authentication architecture as configured by confluent
 
 In confluent, some more advanced SSH features are leveraged to tighten secure use of passwordless SSH and
 known_hosts.  Generally speaking, the details are handled and the operator need not worry about the details.  This
 document is provided to help show the details for those who need to know the mechanisms at work and how they are manipulated.
 
-# SSH certificate authority
+## SSH certificate authority
 
 SSH supports the concept of a certificate authority, allowing one SSH key to vouch for another.  In confluent, `osdeploy initialize -s` requests initialization of such an authority on the local management server.  The private key of that authority is stored as /etc/confluent/ssh/ca and the public key is in /etc/confluent/ssh/ca.pub.  Additionally, the public key is copied to /var/lib/confluent/public/site/ssh/{name}.ca for inclusion for nodes to trust.  Note that
 in a confluent collective, each collective member will generate their own.  When doing a deployment, the deployed node will have a certificate signed by whatever collective member deployed it.  Notably, when a node that will one day be a collective member is installed, it will be signed by the system that provided deployment, *not* itself.
 
-# Certificate authority and role in host key trust
+## Certificate authority and role in host key trust
 
 In traditional ssh usage, each time the user connects to a new host, they are prompted and that specific key is added to ~/.ssh/known_hosts.  This may also be done in /etc/ssh/ssh_known_hosts, to provide that repository system-wide.
 A certificate authority being added to /etc/ssh/ssh_known_hosts extends it's trust over any matching host that has been vouched for by that authority. Here is an example where a 4 collective members get added, and the
@@ -32,7 +32,7 @@ This effectively replaces the requirement to use ~/.ssh/known_hosts for users wi
 whether confluent or other software or manual placement has created the files. This permits custom SSH certificate authorities to be added without confluent being aware of the operational details.
 
 
-# Host key certificate
+## Host key certificate
 During deployment, a node is granted a certificate, and the certificates are stored along the key files in `/etc/ssh/ssh_host_*_key-cert.pub`.  HostCertificate entries are also added to /etc/ssh/sshd_config, for example:
 ```
 HostCertificate /etc/ssh/ssh_host_ecdsa_key-cert.pub
@@ -40,12 +40,12 @@ HostCertificate /etc/ssh/ssh_host_ed25519_key-cert.pub
 HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub
 ```
 
-# Host based authentication
+## Host based authentication
 
 When doing ssh key based authentication, there are two general strategies.  The most popular method involves each user having a ~/.ssh/authorized_keys file enumerating the specific keys that are allowed to authenticate.  
 Confluent focuses on enabling use of the host key.  The first step is for the host key to be recognized by way of known_hosts.  Per the above section, this is handled.  All that is left is enabling host based authentication and specifying which hosts are trusted to vouch for users that connect from them.
 
-# sshd configuration changes for host based authentication
+## sshd configuration changes for host based authentication
 
 The following configuration changes are placed into sshd_config:
 ```
@@ -56,7 +56,7 @@ HostbasedUsesNameFromPacketOnly yes
 The latter permits the client to specify it's own name, rather than relying on reverse DNS.  This means that the client node will do the equivalent of `getent hosts <ip of client nic>` and that result will be the name seen by
 the server.
 
-# ssh client configuration changes for host based authentication
+## ssh client configuration changes for host based authentication
 
 This is an example configuration change made for ssh_config to dictate client behavior, enabling use of the host key to authenticate, and limiting ed25519 toward the end of minimizing key based authentication
 attempts in a system with many key types:
@@ -67,15 +67,15 @@ Host *
     HostbasedKeyTypes *ed25519*
 ```
 
-# Specifying permitted peer nodes
+## Specifying permitted peer nodes
 
 Confluent provides an attribute called `ssh.trustnodes` to designate which managed nodes are allowed to authenticate.  If unspecified, all nodes are assumed to be trusted.  The specified noderange will be expanded during deployment or, as of confluent 3.7.1, refresh of the ssh configuration using `run_remote setupssh`.  The expanded set will be placed into two files, `/etc/ssh/shosts.equiv` to enable users other than root, and `/root/.shosts` to enable node to node ssh as root.  The contents of those two files are the only things effected by this attribute.
 
-# User based authentication for root
+## User based authentication for root
 
 In addition to the host based configuration specified above, the root user on target system is generally given two user keys for `/root/.ssh/authorized_keys` per collective member.  When using `osdeploy initialize -u`, a suitable ssh public key from `/root/.ssh/*.pub` will be copied to `/var/lib/confluent/public/ssh/site/{host}.rootpubkey`.  This key is not used by confluent, but this service is provided as a convenience for operators using root user on the management node.  Note that any other files matching `/var/lib/confluent/public/ssh/site/*.rootpubkey` will also be added, whether confluent added them or not, so other users may be added in this manner as desired.
 
-# User based authentication for confluent
+## User based authentication for confluent
 
 confluent is not permitted to read ssh keys in `/root/.ssh`.  Therefore, running `osdeploy initialize -a` generates a separate user keypair in `/etc/confluent/ssh/`.  This key is used for tasks such as executing ansible plays, or 
 synchronizing files in the `syncfiles` of an OS profile.  The public portion is placed into `/var/lib/confluent/public/site/ssh/*.automationpubkey`

--- a/docs/miscellaneous/sshdesign.md
+++ b/docs/miscellaneous/sshdesign.md
@@ -1,5 +1,7 @@
 ---
 title: Confluent SSH Configuration
+tags:
+  - security
 ---
 
 ## SSH authentication architecture as configured by confluent

--- a/docs/miscellaneous/tlsdesign.md
+++ b/docs/miscellaneous/tlsdesign.md
@@ -2,11 +2,11 @@
 title: Confluent TLS Configuration
 ---
 
-# Challenges of using TLS in a private network
+## Challenges of using TLS in a private network
 
 Using TLS in a private network configuration can be daunting. The usual approach requires that DNS be in order and resolving the way that is intended and imposes a requirement that the user explicitly tell the software correctly the name that will be used.  Further, when faced with multihomed systems, it adds more complexity, as the certificate must cover all possible names and the software must use the correct name at the correct time, depending on context.
 
-# Confluent TLS strategy
+## Confluent TLS strategy
 
 Due to the challenges with relying upon and configuration of DNS, Confluent steers towards use of IP addresses as it goes.  In typical confluent environments, the IP addresses of the management nodes are fixed, and easy to programatically detect the correct one without user guidance.  Thus `osdeploy initialize -t` focuses on enabling IP addresses, for example, here is a typical SAN field for a confluent generated certificate:
 
@@ -15,9 +15,10 @@ X509v3 Subject Alternative Name:
     IP Address:172.30.1.5, IP Address:FDEC:46F7:9B7F:3001:0:0:2:5, IP Address:FE80:0:0:0:A94:EFFF:FE50:BEC2, DNS:172.30.1.5, DNS:fdec:46f7:9b7f:3001::2:5, DNS:fe80::a94:efff:fe50:bec2, DNS:d5
 ```
 
-Note that every possible ip address is added, and added both properly as IP address fields, and as DNS fields, due to certain TLS clients incorrectly skipping IP address fields.
+!!! note
+    Every possible ip address is added, and added both properly as IP address fields, and as DNS fields, due to certain TLS clients incorrectly skipping IP address fields.
 
-# The confluent TLS authority
+## The confluent TLS authority
 
 To allow easily updating the certificate to accommodate IP address changes, confluent tends to make it's own certificate authority:
 ```
@@ -38,7 +39,7 @@ lrwxrwxrwx. 1 root root   6 Mar 16 09:17 a8959d66.0 -> d7.pem
 -rw-r--r--. 1 root root 656 Mar 23  2022 d8.pem
 ```
 
-# Using a custom certificate authority
+## Using a custom certificate authority
 
 Unfortunately, while this approach makes things easier for those that do not wish to manually sort out the details of DNS and TLS, it poses a challenge for those that wish to use a TLS certificate globally.  There are some options to proceed.
 

--- a/docs/miscellaneous/tlsdesign.md
+++ b/docs/miscellaneous/tlsdesign.md
@@ -1,5 +1,7 @@
 ---
 title: Confluent TLS Configuration
+tags:
+  - security
 ---
 
 ## Challenges of using TLS in a private network

--- a/docs/miscellaneous/xccdeployment.md
+++ b/docs/miscellaneous/xccdeployment.md
@@ -11,72 +11,84 @@ when doing deployment over a routed network with minimal external configuration.
 For static IP deployments, it is important that confluent be given the prefix
 length and the gateway.
 
-    # nodeattrib d1 net.ipv4_address=192.168.16.35/24 net.ipv4_gateway=192.168.16.254
-    d1: 192.168.16.35/24
-    d1: 192.168.16.254
+```bash
+# nodeattrib d1 net.ipv4_address=192.168.16.35/24 net.ipv4_gateway=192.168.16.254
+d1: 192.168.16.35/24
+d1: 192.168.16.254
+```
 
 ### Set the desired profile to be pending
 
-    # nodeattrib d1-d4 deployment.pendingprofile=rocky-8.7-x86_64-default
-    d1: rocky-8.7-x86_64-default
-    d2: rocky-8.7-x86_64-default
-    d3: rocky-8.7-x86_64-default
-    d4: rocky-8.7-x86_64-default
+```bash
+# nodeattrib d1-d4 deployment.pendingprofile=rocky-8.7-x86_64-default
+d1: rocky-8.7-x86_64-default
+d2: rocky-8.7-x86_64-default
+d3: rocky-8.7-x86_64-default
+d4: rocky-8.7-x86_64-default
+```
 
 ### Create an identity image
 
 The identity image contains credentials, network configuration, and information
 about the deployment server.
 
-    # confetty set /noderange/d1-d4/deployment/ident_image=create
-    created: nodes/d2/deployment/ident_image
-    created: nodes/d4/deployment/ident_image
-    created: nodes/d3/deployment/ident_image
-    created: nodes/d1/deployment/ident_image
+```bash
+# confetty set /noderange/d1-d4/deployment/ident_image=create
+created: nodes/d2/deployment/ident_image
+created: nodes/d4/deployment/ident_image
+created: nodes/d3/deployment/ident_image
+created: nodes/d1/deployment/ident_image
+```
 
 ### Upload the identity image to the xClarity Controller
 
-    # noderun d1-d4 nodemedia {node} upload /var/lib/confluent/private/identity_images/{node}.img
-    d1: d1: initializing:   0%
-    d2: d2: initializing:   0%
-    d4: d4: initializing:   0%
-    d3: d3: initializing:   0%
-    d1: d1: upload: 100%
-    d2: d2: upload: 100%
-    d4: d4: upload: 100%
-    d3: d3: upload: 100%
-    d4: d4: complete: 100%
-    d3: d3: complete: 100%
-    d1: d1: complete: 100%
-    d2: d2: complete: 100%
-    d4: d4: d4.img
-    d3: d3: d3.img
-    d2: d2: d2.img
-    d1: d1: d1.img
+```bash
+# noderun d1-d4 nodemedia {node} upload /var/lib/confluent/private/identity_images/{node}.img
+d1: d1: initializing:   0%
+d2: d2: initializing:   0%
+d4: d4: initializing:   0%
+d3: d3: initializing:   0%
+d1: d1: upload: 100%
+d2: d2: upload: 100%
+d4: d4: upload: 100%
+d3: d3: upload: 100%
+d4: d4: complete: 100%
+d3: d3: complete: 100%
+d1: d1: complete: 100%
+d2: d2: complete: 100%
+d4: d4: d4.img
+d3: d3: d3.img
+d2: d2: d2.img
+d1: d1: d1.img
+```
 
 ### Attach the boot image for the desired profile
 
-    # nodemedia d1-d4 attach http://172.30.1.5/confluent-public/os/rocky-8.7-x86_64-default/boot.img
-    d1: http://172.30.1.5/confluent-public/os/rocky-8.7-x86_64-default/boot.img (insecure)
-    d1: d1.img
-    d2: http://172.30.1.5/confluent-public/os/rocky-8.7-x86_64-default/boot.img (insecure)
-    d2: d2.img
-    d3: http://172.30.1.5/confluent-public/os/rocky-8.7-x86_64-default/boot.img (insecure)
-    d3: d3.img
-    d4: http://172.30.1.5/confluent-public/os/rocky-8.7-x86_64-default/boot.img (insecure)
-    d4: d4.img
+```bash
+# nodemedia d1-d4 attach http://172.30.1.5/confluent-public/os/rocky-8.7-x86_64-default/boot.img
+d1: http://172.30.1.5/confluent-public/os/rocky-8.7-x86_64-default/boot.img (insecure)
+d1: d1.img
+d2: http://172.30.1.5/confluent-public/os/rocky-8.7-x86_64-default/boot.img (insecure)
+d2: d2.img
+d3: http://172.30.1.5/confluent-public/os/rocky-8.7-x86_64-default/boot.img (insecure)
+d3: d3.img
+d4: http://172.30.1.5/confluent-public/os/rocky-8.7-x86_64-default/boot.img (insecure)
+d4: d4.img
+```
 
 ### Boot nodes to usb to commence deployment
 
-    # nodeboot d1-d usb
-    d1: usb
-    d1: reset
-    d2: usb
-    d2: reset
-    d3: usb
-    d3: reset
-    d4: usb
-    d4: reset
+```bash
+# nodeboot d1-d usb
+d1: usb
+d1: reset
+d2: usb
+d2: reset
+d3: usb
+d3: reset
+d4: usb
+d4: reset
+```
 
 ### Deployment should proceed to completion
 

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -1,0 +1,9 @@
+---
+title: Tags
+---
+
+# Tags
+
+Browse the documentation by topic. Each tag lists the pages associated with it.
+
+<!-- material/tags -->

--- a/docs/troubleshooting/confluentosdeployts.md
+++ b/docs/troubleshooting/confluentosdeployts.md
@@ -2,11 +2,11 @@
 title: Troubleshooting issues with confluent OS deployment
 ---
 
-# IPv6 configuration
+## IPv6 configuration
 
 Deployment interfaces must have IPv6 enabled, with at least an automatic fe80:: address.  Generally this is default network interface configuration.  IPv6 need only be enabled, it need not be given any address manually, by DHCP, or by route advertisements, the automatic fe80:: addresses suffice.
 
-# Unable to import media after aborting with control-C or an error being encountered
+## Unable to import media after aborting with control-C or an error being encountered
 
 An attempt to import media after an error or abort may result in:
 
@@ -26,31 +26,31 @@ centos_stream-8.4-x86_64
 Deleted: deployment/importing/centos_stream-8.4-x86_64
 ```
 
-# Can't ssh from the management node to a managed node after deployment, or from a managed node to another managed node after deployment
+## Can't ssh from the management node to a managed node after deployment, or from a managed node to another managed node after deployment
 
 If the ssh ca certificate is changed on the management node, then confluent needs to be updated with this by running "osdeploy initialize -k".  This will allow for ssh from the management node to the managed nodes to work.
 
 To make sure ssh from one confluent-deployed managed node to another works, after the ssh ca certificate is changed on the management node, if using image-based (versus separate kernel and initrd downloads) deployment, then the OS profile image needs to be updated with "osdeploy updateboot <profile name>" prior to OS deployment.
 
-# Can't access OS repos from managed nodes after confluent deployment
+## Can't access OS repos from managed nodes after confluent deployment
 
 The OS repo URLs are set to the specific profile used to perform the deployment with confluent on a managed node.  If that profile is moved, renamed, or deleted on the management node, then the managed node will not longer be able to access those repos.  This is different from how this was done with xCAT where different install profiles pointed to a common install source location (this actually is deduplicated in confluent as well, but the URLs on the managed nodes are specific to the deployment profile).
 
-# Managed node may hang during confluent OS deployment
+## Managed node may hang during confluent OS deployment
 
 When performing OS deployment with confluent, the managed node may hang, for example at "Started cancel waiting for multipath siblings of <drive>" when deploying RHEL 8.3.  This can be caused by the collective.managercandidates nodattribute containing a management node that is not actually defined as a node in the confluent database.  Note that this has to be defined exactly as it appears in the "collective show" command output.  For example, if the management node is shown in "collective show" as "mn.domain" then that management node has to be defined with the nodename "mn.domain" in confluent, as opposed to just "mn".
 
 
-# Issues with SSH within a cluster after adding an additional collective member
+## Issues with SSH within a cluster after adding an additional collective member
 
 After adding a collective member, it is necessary to run `nodeapply -k <noderange>` on existing nodes, as well as `osdeploy initialize -k` on existing collective members after setting up SSH on the new collective member.
 
-# Regenerating SSH host certificates
+## Regenerating SSH host certificates
 
 If there is a requiremennt to regenerate SSH keys after installation and new
 certificates are needed, this can be addressed by running `nodeapply <noderange> -k`
 
-# Unable to ssh from one managed node to another on an interface which has a DNS hostname that doesn't match the confluent nodename
+## Unable to ssh from one managed node to another on an interface which has a DNS hostname that doesn't match the confluent nodename
 
 In some cases ssh from one managed node to another will fail with the following error:
 
@@ -64,7 +64,7 @@ This can be addressed by running `nodeapply -k <noderange>'
 
 
 
-# Confluent OS profile updates are not automatically applied on confluent updates
+## Confluent OS profile updates are not automatically applied on confluent updates
 
 The default confluent profiles for OSes (e.g. RHEL 8.4, SLE 15.3, etc., including genesis) do occasionally get updates as part of a confluent update.  However, these aren't applied automatically.  To opt into updates, run
 
@@ -74,15 +74,15 @@ osdeploy rebase <profile name>
 
 Note this will try to preserve customization, but heavy customization may make files incompatible.
 
-# Confluent does not support secure boot with PXE. 
+## Confluent does not support secure boot with PXE. 
 
 The ipxe boot loader that confluent uses in not signed, because of this an attempt to do secure boot with PXE will result in a secure boot violation. To do a network boot using confluent with secure boot enabled either http or https boot must be used. 
 
-# KVM virtual machines immediately fail to netboot when using UEFI firmware with confluent
+## KVM virtual machines immediately fail to netboot when using UEFI firmware with confluent
 
 This is due to iPXE not being compatible with secureboot.  For now, disable secureboot when using UEFI with KVM virtualization, since the KVM firmware does not support HTTP boot.
 
-# System gets non-desired IP address when being deployed or booting genesis
+## System gets non-desired IP address when being deployed or booting genesis
 
 One possible reason for this to occur is if the net.\<inteface name\>.hostname and net.\<interface name\>.ipv4_address nodeattributes for a node are defined, and the network configuration of the confluent server and network are such that there more than one set of net.\<interface name\>.hostname and net.\<interface name\>.ipv4_address settings that could match a particular L2 network.  In this case which of the net.\<interface name\>.* settings would be applied to the boot interface on the netbooting node may not be consistent from boot to boot.
 

--- a/docs/troubleshooting/xcatosdeploymentts.md
+++ b/docs/troubleshooting/xcatosdeploymentts.md
@@ -2,11 +2,11 @@
 title: Troubleshooting issues with xCAT OS deployment and diskless image creation/boot
 ---
 
-# xCAT OS deployment or diskless image boot fails with message regarding ib=dhcp
+## xCAT OS deployment or diskless image boot fails with message regarding ib=dhcp
 
 The ib=dhcp kernel command line argument is added by default to the bootloader configuration files on the xCAT management server at /tftpboot/xcat/xnba/nodes/<node>* .  When a kernel command line paramer is set to set the ip= argument more explicitly, for example using bootparams.addkcmdline for boot over IB, then the ip=dhcp argument in the kernel command line arguments in the bootloader configuration file is superfluous and can cause problems.  To work-around this error the "ip=dhcp" entry in the bootloader configuration file should be removed.  Note, this will have to be re-done, after performing nodeset.
 
-# After creating an xCAT (Extreme Cluster Administration Toolkit) stateless image of SLES 15.2 and deploying it, SSH connections to the booted SLES 15.2 image fail
+## After creating an xCAT (Extreme Cluster Administration Toolkit) stateless image of SLES 15.2 and deploying it, SSH connections to the booted SLES 15.2 image fail
 
 This presumes the creation of an xCAT stateless image via the process described at
                                                        

--- a/docs/user_reference/attributeexpressions.md
+++ b/docs/user_reference/attributeexpressions.md
@@ -1,5 +1,7 @@
 ---
 title: Attribute Expressions
+tags:
+  - reference
 ---
 
 In confluent, any attribute may either be a straightforward value, or an expression

--- a/docs/user_reference/chainedsmmdiscovery.md
+++ b/docs/user_reference/chainedsmmdiscovery.md
@@ -9,7 +9,7 @@ There are two strategies.  The [first](#fully-out-of-band-discovery) is more res
 
 The [other](#pxe-driven-discovery) works with older chained SMM firmware, but requires nodes to attempt PXE boot.
 
-# Fully out of band discovery
+## Fully out of band discovery
 
 * The Ethernet switch must have LLDP enabled.
 * Confirm that you have confluent version 1.8.0, and that all SMMs will at
@@ -23,7 +23,7 @@ The [other](#pxe-driven-discovery) works with older chained SMM firmware, but re
   discovery [here](confluentdiscovery.md).
 
 
-# PXE Driven Discovery
+## PXE Driven Discovery
 If using older SMM firmware in a chain, or else wanting to drive discovery from the node network side
 rather than the SMM side, the method with PXE may be used.
 

--- a/docs/user_reference/confluentdiscovery.md
+++ b/docs/user_reference/confluentdiscovery.md
@@ -1,5 +1,7 @@
 ---
 title: Node discovery and autoconfiguration with confluent
+tags:
+  - discovery
 ---
 
 !!! note

--- a/docs/user_reference/confluentdiscovery.md
+++ b/docs/user_reference/confluentdiscovery.md
@@ -2,13 +2,14 @@
 title: Node discovery and autoconfiguration with confluent
 ---
 
-Note that discovery is an optional portion of confluent that may be skipped.
-Further, the discovery process does not require that the user log into the
-target and do anything like change password or network configuration. It is
-designed to specifically help when a target has not been configured at all and
-implements everything it needs to automatically change password and adjust
-networking as required. If you do adjust networking, user, and password
-through other means, then this portion may be skipped.
+!!! note
+    Discovery is an optional portion of confluent that may be skipped.
+    Further, the discovery process does not require that the user log into the
+    target and do anything like change password or network configuration. It is
+    designed to specifically help when a target has not been configured at all and
+    implements everything it needs to automatically change password and adjust
+    networking as required. If you do adjust networking, user, and password
+    through other means, then this portion may be skipped.
 
 While it is possible to use confluent by directly specifying the pre-configured 
 address, username, and password of a BMC, confluent also has the ability to 

--- a/docs/user_reference/confluentrackview.md
+++ b/docs/user_reference/confluentrackview.md
@@ -7,7 +7,7 @@ racks and organize the racks into rows in the datacenter:
 
 ![Example Rackview](../assets/rackview.png)
 
-# Setting up a rackmount system
+## Setting up a rackmount system
 
 The three attributes relevant for a node are location.rack, location.u, and location.row. Ensure all three are set to a value. For multi-u systems, specify the lowest U. It is optional, though
 recommended to also set location.height, as that will help the rackview draw more quickly than auto-detecting the component height.
@@ -23,7 +23,7 @@ o2: location.u: 32
 ```
 
 
-# Setting up an enclosure/dense system
+## Setting up an enclosure/dense system
 
 The recommended attributes to set are for the enclosure to be specified according to the same instructions as a rackmount system above. The servers themselves
 should not have any location information, as their location will be defined by enclosure.manager and enclosure.bay within the chassis definition.

--- a/docs/user_reference/noderange.md
+++ b/docs/user_reference/noderange.md
@@ -1,5 +1,7 @@
 ---
 title: Noderange Syntax
+tags:
+  - reference
 ---
 
 Confluent implements a powerful language to indicate a target

--- a/docs/user_reference/osdeploy.md
+++ b/docs/user_reference/osdeploy.md
@@ -1,5 +1,7 @@
 ---
 title: OS Deployment concepts
+tags:
+  - deployment
 ---
 
 Confluent supports a number of mechanisms for operating system deployment, with various benefits and drawbacks.

--- a/docs/user_reference/osdeploy.md
+++ b/docs/user_reference/osdeploy.md
@@ -37,7 +37,7 @@ approach leverages the OS deployment automation supported natively by the provid
 | OS                  | Mechanism              |
 |---------------------|------------------------|
 | Red Hat and similar | Kickstart (Anaconda)   |
-| Ubuntu              | cloud-init (Subiquitiy)|
+| Ubuntu              | cloud-init (Subiquity)|
 | SUSE                | Autoyast               |
 | Debian              | Debian-Installer       |
 | VMWare              | Kickstart (Weasel)     |
@@ -50,7 +50,7 @@ The benefits of this approach are:
 
 ## Image approach
 
-For many platforms, Confluent further supports an 'image' based approach goverened by 'imgutil'.  This approach works with chroot-style directory trees or cloning to maintain an image.
+For many platforms, Confluent further supports an 'image' based approach governed by 'imgutil'.  This approach works with chroot-style directory trees or cloning to maintain an image.
 
 Generally speaking, the benefits and drawbacks of an image based approach are:
 
@@ -85,11 +85,11 @@ given multipath capabilities, allowing continued functionality if one confluent 
 
 | Benefits | Drawbacks |
 | ------ | -------- |
-| <ul><li>No local disk required</li><li>Dramatically reduced memory requirements compared with traditional diskless approaches</li><li>Faster diskless boot compared with traditional diskless approaches</li><li>OS may contain arbitraily large content without risking extra memory consumption</li></ul> | <ul><li>Nodes have an ongoing dependency on the confluent infrastructure and profile's existance on the servers. Mitigated by using a collective to provide HA capabilities.</li><li>Writing to the local filesystem (logging, scratch, updates, installs) will increase memory consumption
+| <ul><li>No local disk required</li><li>Dramatically reduced memory requirements compared with traditional diskless approaches</li><li>Faster diskless boot compared with traditional diskless approaches</li><li>OS may contain arbitrarily large content without risking extra memory consumption</li></ul> | <ul><li>Nodes have an ongoing dependency on the confluent infrastructure and profile's existence on the servers. Mitigated by using a collective to provide HA capabilities.</li><li>Writing to the local filesystem (logging, scratch, updates, installs) will increase memory consumption
 
 #### untethered (stateless/diskless)
 
-* `confluent_image=untethered` - This will instruct the OS to download the image up front and run out of compressed RAM instead of disk or fetching on-demand.  This results in increased [memory consuption](diskless_memory_usage.md).  Benefits and drawbacks:
+* `confluent_image=untethered` - This will instruct the OS to download the image up front and run out of compressed RAM instead of disk or fetching on-demand.  This results in increased [memory consumption](diskless_memory_usage.md).  Benefits and drawbacks:
 
 | Benefits | Drawbacks |
 | ------ | -------- |

--- a/docs/user_reference/suse15deploy.md
+++ b/docs/user_reference/suse15deploy.md
@@ -2,8 +2,9 @@
 title: OS Deployment Notes for SLE/SUSE 15
 ---
 
-Note that if using xCAT and wanting to use the `reboot` postscript, it must be specified as
-in `postbootscripts` rather than `postscripts`.
+!!! note
+    If using xCAT and wanting to use the `reboot` postscript, it must be specified as
+    in `postbootscripts` rather than `postscripts`.
 
 If executing genimage multiple times, it may be required to delete the image between runs. This
 is due to certain assumptions that, among other things, could erase /etc/passwd without

--- a/docs/user_reference/switchportattribs.md
+++ b/docs/user_reference/switchportattribs.md
@@ -1,5 +1,7 @@
 ---
 title: Configuring network port attributes
+tags:
+  - networking
 ---
 
 In xCAT and confluent, the [discovery process](confluentdiscovery.md) can use ethernet switch connectivity to assess real node identity to use in deploying configuration and gathering info such as mac addresses.

--- a/docs/user_reference/thermalpowerconfluent.md
+++ b/docs/user_reference/thermalpowerconfluent.md
@@ -1,5 +1,7 @@
 ---
 title: Power and Cooling Monitoring with Confluent
+tags:
+  - hardware
 ---
 
 Confluent provides access to various power and cooling data on the monitored hardware.

--- a/docs/user_reference/ubuntudeploy.md
+++ b/docs/user_reference/ubuntudeploy.md
@@ -30,4 +30,5 @@ defined in both files. If you are having issues with the network on the node, we
 `00-installer-config.yaml` file given that you have the right networking config in the interface file configured by 
 confluent. 
 
-Note: The values set in the `{interface}-confluentcfg.yaml` file are retrieved from the nodeattributes set for that particular node
+!!! note
+    The values set in the `{interface}-confluentcfg.yaml` file are retrieved from the nodeattributes set for that particular node

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,7 +90,11 @@ markdown_extensions:
   - pymdownx.mark
   - pymdownx.smartsymbols
   - pymdownx.snippets
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.tasklist:
@@ -99,10 +103,21 @@ markdown_extensions:
 
 plugins:
   - search
+  - tags
   - blog:
       blog_dir: release_notes
       blog_toc: true
+  - rss:
+      match_path: release_notes/posts/.*
+      date_from_meta:
+        as_creation: date
+  # Social cards are dormant by default. To enable, install the Cairo system
+  # libraries (e.g. libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev
+  # libpng-dev) in the build environment and set the SOCIAL_CARDS env var.
+  - social:
+      enabled: !ENV [SOCIAL_CARDS, false]
   - privacy
+  - glightbox
   - awesome-nav
   - git-revision-date-localized:
       type: timeago

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,8 @@ mkdocs-material
 mkdocs-awesome-nav
 mkdocs-git-revision-date-localized-plugin
 mkdocs-minify-plugin
+mkdocs-glightbox
+mkdocs-rss-plugin
+# Required by the Material "social" plugin (social cards), built in CI
+pillow
+cairosvg


### PR DESCRIPTION
## Summary

Modernises the documentation in three self-contained commits. No source content
is lost and the site builds cleanly with `mkdocs build` (no content warnings).
Documentation prose remains US-spelled for consistency with the project.

## Changes

### 1. Code-block modernisation
Convert the remaining indented code blocks to fenced blocks with a language hint
across `advanced_topics/`, `miscellaneous/`, `developer/api.md`, and
`downloads.md`, enabling syntax highlighting and the copy-to-clipboard button to
match the rest of the site. Pages whose indentation is prose/list layout (e.g.
`miscellaneous/samplepostscripts.md`) and the generated `manuals/` pages are left
untouched.

### 2. Heading and prose cleanup
- Normalise heading levels so each page has a single H1 (the page title) with
  sections at H2 and below, fixing pages that used multiple H1s (which flattened
  the on-page table of contents).
- Convert legacy setext (`====` / `----`) headings to ATX (`#` / `##`).
- Convert standalone "Note that ..." paragraphs to Material `!!! note`
  admonitions.
- Fix spelling typos (pseudo, governed, existence, consumption, arbitrarily,
  supported, minimum, Subiquity).

### 3. Material site features
- **Tags**: a tag taxonomy with a `tags.md` index, seeded across key pages.
- **RSS feed** for the release-notes blog (`mkdocs-rss-plugin`).
- **Image zoom** on screenshots (`mkdocs-glightbox`).
- **Mermaid** diagram support via a `pymdownx.superfences` custom fence.
- **Social cards** (Material `social` plugin), dormant by default
  (`enabled: !ENV [SOCIAL_CARDS, false]`) so builds are unaffected until a
  maintainer opts in by installing Cairo and setting `SOCIAL_CARDS`.

## New dependencies (`requirements.txt`)
`mkdocs-glightbox`, `mkdocs-rss-plugin`, and `pillow` + `cairosvg` (only used by
the dormant social-cards plugin).

## Notes
- The four architecture SVGs (`hierarchy`, `redundant_hierarchy`, `segmented`,
  `flat`) could later be migrated to inline Mermaid now that the capability is
  enabled.
- See `CHANGELOG.md` for the full breakdown.