### PR TITLE
Switch to ProperDocs + mkdocs-materialx for now

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,11 +23,11 @@ jobs:
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
       - uses: actions/cache@v5
         with:
-          key: mkdocs-material-${{ env.cache_id }}
+          key: mkdocs-materialx-${{ env.cache_id }}
           path: ~/.cache
           restore-keys: |
-            mkdocs-material-
-      - name: Install Material for MkDocs requirements
+            mkdocs-materialx-
+      - name: Install MaterialX requirements
         run: pip install -r requirements.txt
       - name: Install man pages and social cards requirements
         run: sudo apt-get install -y --no-install-recommends --no-install-suggests ronn libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev
@@ -45,4 +45,4 @@ jobs:
       - name: Deploy to GitHub Pages
         env:
           SOCIAL_CARDS: true
-        run: mkdocs gh-deploy --force
+        run: properdocs gh-deploy --force

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all:
 	./makeattribdoc
 	./makeman
-	python3 -m mkdocs build
+	python3 -m properdocs build
 
 testupload: all
 	rsync -a _site/* taurus:/var/www/html/users

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 [![Build Status](https://github.com/xcat2/confluent-docs/workflows/build/badge.svg)](https://github.com/xcat2/confluent-docs/actions) [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/xcat2/confluent-docs/blob/master/LICENSE)
 
-The [confluent documentation](https://xcat2.github.io/confluent-docs/) is built using [MkDocs](https://www.mkdocs.org/). All **Markdown** files in the `docs` directory are automatically added to the documentation.  
+The [confluent documentation](https://xcat2.github.io/confluent-docs/) is built using [ProperDocs](https://properdocs.org/). All **Markdown** files in the `docs` directory are automatically added to the documentation.  
 Navigation can be customized using `.nav.yml` files located in each directory.
 
-Since Markdown is supported by most Git web hosting platforms, you can also view or edit the documentation online without using MkDocs.
+Since Markdown is supported by most Git web hosting platforms, you can also view or edit the documentation online without using ProperDocs.
 
 ## Prerequisites
 
-To generate the documentation you need the Python package [mkdocs-material](https://squidfunk.github.io/mkdocs-material/) along with some additional plugins. To install the required dependencies, run:
+To generate the documentation you need the Python package [mkdocs-materialx](https://jaywhj.github.io/mkdocs-materialx/) along with some additional plugins. To install the required dependencies, run:
 
 ```bash
 pip3 install -r requirements.txt --user
@@ -24,7 +24,7 @@ Furthermore, you should have the [confluent repository](https://github.com/xcat2
 For development purposes, you can use the following command to start a local web server that watches the files in the `docs` directory and updates the documentation on changes:
 
 ```bash
-mkdocs serve
+properdocs serve
 ```
 
 Then, access the live documentation at: [http://127.0.0.1:8000](http://127.0.0.1:8000)
@@ -36,7 +36,7 @@ To build static HTML pages, use either:
 ```bash
 ./makeattribdoc   # generate node_attributes.md from ../confluent
 ./makeman         # generate man pages from ../confluent
-mkdocs build      # build HTML pages
+properdocs build  # build HTML pages
 ```
 
 or

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -13,7 +13,8 @@ copyright: Copyright &copy; Confluent Community
 site_dir: _site
 
 theme:
-  name: material
+  name: materialx
+  language: en
   favicon: assets/icon.png
   #logo:
   features:
@@ -119,8 +120,9 @@ plugins:
   - privacy
   - glightbox
   - awesome-nav
-  - git-revision-date-localized:
+  - document-dates:
       type: timeago
-      enable_creation_date: true
+      position: bottom
+      show_author: false
   - minify:
       minify_html: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-mkdocs-material
+mkdocs-materialx==10.1.8
+properdocs>=1.6.5
 mkdocs-awesome-nav
-mkdocs-git-revision-date-localized-plugin
-mkdocs-minify-plugin
-mkdocs-glightbox
+mkdocs-minify-plugin>=0.7
+mkdocs-glightbox>=0.5
 mkdocs-rss-plugin
-# Required by the Material "social" plugin (social cards), built in CI
-pillow
-cairosvg
+# Required by the "social" plugin (social cards), built in CI
+pillow>=10.2
+cairosvg>=2.6


### PR DESCRIPTION
It's maintained and we can keep using it until [Zensical](https://zensical.org/) reaches feature parity (see #14).

Furthermore, mkdocs-document-dates is way faster than git-revision-date-localized-plugin.